### PR TITLE
Index fix

### DIFF
--- a/liberty/LibertyReader.cc
+++ b/liberty/LibertyReader.cc
@@ -2524,7 +2524,7 @@ LibertyReader::endOutputCurrentRiseFall(LibertyGroup *group)
     slew_axis->findAxisIndex(waveform->slew(), slew_index, slew_exists);
     cap_axis->findAxisIndex(waveform->cap(), cap_index, cap_exists);
     if (slew_exists && cap_exists) {
-      size_t index = slew_index * slew_axis->size() + cap_index;
+      size_t index = slew_index * cap_axis->size() + cap_index;
       current_waveforms[index] = waveform->stealCurrents();
       (*ref_times)[slew_index] = waveform->referenceTime();
     }

--- a/search/Sta.cc
+++ b/search/Sta.cc
@@ -366,7 +366,8 @@ Sta::updateComponentsState()
 void
 Sta::makeReport()
 {
-  report_ = new ReportTcl();
+  if (!report_) // Let's reuse report if it is already created (could be specifically created non Tcl report)
+    report_ = new ReportTcl();
 }
 
 void


### PR DESCRIPTION
In the LibertyReader the index of the current_waveforms was calculated as slew_index * slew_axis->size() + cap_index, but should be slew_index * cap_axis->size() + cap_index (same as in the OutputWaveforms::currentWaveform function).

This commit fix the occasional memory corruption issues caused by above index calculated wrong and been outside allocated array.