### PR TITLE
Fix parsing error with >2 attributes

### DIFF
--- a/test/verilog_attribute.ok
+++ b/test/verilog_attribute.ok
@@ -1,2 +1,4 @@
 top_instance:"counter" attribute "src" = synthesis/tests/counter.v:16.1-32.10
 instance: _1415_ attribute "src" = synthesis/tests/counter.v:22.3-28.6
+instance: _1415_ attribute "attr1" = test_attr1
+instance: _1415_ attribute "attr2" = test_attr2

--- a/test/verilog_attribute.tcl
+++ b/test/verilog_attribute.tcl
@@ -11,4 +11,8 @@ puts "top_instance:\"$cell_name\" attribute \"src\" = $src_location"
 
 set instance_name "_1415_"
 set instance_src_location [[sta::find_instance $instance_name] get_attribute "src"]
+set instance_attr1 [[sta::find_instance $instance_name] get_attribute "attr1"]
+set instance_attr2 [[sta::find_instance $instance_name] get_attribute "attr2"]
 puts "instance: $instance_name attribute \"src\" = $instance_src_location"
+puts "instance: $instance_name attribute \"attr1\" = $instance_attr1"
+puts "instance: $instance_name attribute \"attr2\" = $instance_attr2"

--- a/test/verilog_attribute.v
+++ b/test/verilog_attribute.v
@@ -11,7 +11,7 @@ module counter(clk, reset, in, out);
   (* src = "synthesis/tests/counter.v:18.14-18.19" *)
   input reset;
   input in;
-  (* src = "synthesis/tests/counter.v:22.3-28.6" *)
+  (* src = "synthesis/tests/counter.v:22.3-28.6", attr1 = "test_attr1", attr2 = "test_attr2" *)
   sky130_fd_sc_hd__dfrtp_1 _1415_ (
     .CLK(clk),
     .D(in),

--- a/verilog/VerilogParse.yy
+++ b/verilog/VerilogParse.yy
@@ -499,7 +499,7 @@ attr_specs:
 	{ $$ = new sta::VerilogAttributeEntrySeq;
 	  $$->push_back($1);
 	}
-| attr_spec ',' attr_spec
+| attr_specs ',' attr_spec
 	{ $$->push_back($3); }
 	;
 


### PR DESCRIPTION
Addressing issue #19, introduced with #11. Credits to @QuantamHD for identifying the fix.

0-2 attributes could be parsed correctly, but 3+ produced an error. This was due to a typo in the recursive attribute parsing of the verilog yacc file.

Fixed the error, added a test case with 3 attributes. Problem appears to be resolved now, contributing back upstream.