### PR TITLE
Fixes memory leak in verilog attribute code.

### DIFF
--- a/verilog/VerilogParse.yy
+++ b/verilog/VerilogParse.yy
@@ -505,9 +505,14 @@ attr_specs:
 
 attr_spec:
 	ID
-	{ $$ = new sta::VerilogAttributeEntry($1, "1"); }
+	{ $$ = new sta::VerilogAttributeEntry($1, "1");
+	  delete[] $1;
+	}
 | 	ID '=' attr_spec_value
-	{ $$ = new sta::VerilogAttributeEntry($1, $3); }
+	{ $$ = new sta::VerilogAttributeEntry($1, $3); 
+	  delete[] $1;
+	  delete[] $3;
+	}
 	;
 
 attr_spec_value:

--- a/verilog/VerilogReader.cc
+++ b/verilog/VerilogReader.cc
@@ -424,8 +424,11 @@ VerilogReader::makeDcl(PortDirection *dir,
       dcl_count_++;
       return new VerilogDcl(dir, assign_args, attribute_stmts, line);
     }
-    else
+    else {
+      attribute_stmts->deleteContents();
+      delete attribute_stmts;
       return nullptr;
+    }
   }
   else {
     dcl_count_++;


### PR DESCRIPTION
There appears to be two leaks one with string handling, and one with Dcl not freeing the attribute stmt list when it returns nullptr.