### PR TITLE
Update Property.cc to support more property types in filter expressions

### DIFF
--- a/search/Property.cc
+++ b/search/Property.cc
@@ -889,6 +889,7 @@ getProperty(const Instance *inst,
 	    Sta *sta)
 {
   auto network = sta->cmdNetwork();
+  LibertyCell *libertyCell = network->libertyCell(inst);
   if (stringEqual(property, "name"))
     return PropertyValue(network->name(inst));
   else if (stringEqual(property, "full_name"))
@@ -899,6 +900,18 @@ getProperty(const Instance *inst,
     return PropertyValue(network->libertyCell(inst));
   else if (stringEqual(property, "cell"))
     return PropertyValue(network->cell(inst));
+    else if (stringEqual(property, "is_hierarchical"))
+    return PropertyValue(network->isHierarchical(inst));
+  else if (stringEqual(property, "is_buffer"))
+    return PropertyValue(libertyCell && libertyCell->isBuffer());
+  else if (stringEqual(property, "is_clock_gate"))
+    return PropertyValue(libertyCell && libertyCell->isClockGate());
+  else if (stringEqual(property, "is_inverter"))
+    return PropertyValue(libertyCell && libertyCell->isInverter());
+  else if (stringEqual(property, "is_macro"))
+    return PropertyValue(libertyCell && libertyCell->isMacro());
+  else if (stringEqual(property, "is_memory_cell"))
+    return PropertyValue(libertyCell && libertyCell->isMemory());
   else
     throw PropertyUnknown("instance", property);
 }
@@ -918,6 +931,10 @@ getProperty(const Pin *pin,
     return PropertyValue(network->pathName(pin));
   else if (stringEqual(property, "direction"))
     return PropertyValue(network->direction(pin)->name());
+  else if (stringEqual(property, "is_hierarchical"))
+    return PropertyValue(network->isHierarchical(pin));
+  else if (stringEqual(property, "is_port"))
+    return PropertyValue(network->isTopLevelPort(pin));
   else if (stringEqual(property, "is_register_clock")) {
     const LibertyPort *port = network->libertyPort(pin);
     return PropertyValue(port && port->isRegClk());
@@ -1163,10 +1180,18 @@ getProperty(Clock *clk,
     return PropertyValue(clk->period(), sta->units()->timeUnit());
   else if (stringEqual(property, "sources"))
     return PropertyValue(clk->pins());
+  else if (stringEqual(property, "generated"))
+    return PropertyValue(clk->isGenerated());
+  else if (stringEqual(property, "virtual"))
+    return PropertyValue(clk->isVirtual());
   else if (stringEqual(property, "propagated"))
     return PropertyValue(clk->isPropagated());
   else if (stringEqual(property, "is_generated"))
     return PropertyValue(clk->isGenerated());
+  else if (stringEqual(property, "is_virtual"))
+    return PropertyValue(clk->isVirtual());
+  else if (stringEqual(property, "is_propagated"))
+    return PropertyValue(clk->isPropagated());
   else
     throw PropertyUnknown("clock", property);
 }


### PR DESCRIPTION
Add support for getting more property types in filter expressions on instances, pins, and clocks.

Instances:
- Get whether is {hierarchical, buffer, clock gate, inverter, macro, memory cell}

Pins:
- Get whether is {hierarchical, port}

Clocks:
- Get whether is {generated, virtual, propagated}
- Allow two forms: `generated`, `is_generated`, ...