### PR TITLE
Fix clang warnings about wrong abs

### DIFF
--- a/power/ReadVcdActivities.cc
+++ b/power/ReadVcdActivities.cc
@@ -29,6 +29,7 @@
 
 namespace sta {
 
+using std::abs;
 using std::min;
 using std::to_string;
 


### PR DESCRIPTION
      using integer absolute value function 'abs' when argument is of floating
      point type [-Werror,-Wabsolute-value]
      if (abs((clk_period - sim_period) / clk_period) > .1)
          ^