### PR TITLE
Update `Dockerfile.ubuntu_18.04` and remove `filesystem` dependence completely in `Main.cc`

### DIFF
--- a/Dockerfile.ubuntu_18.04
+++ b/Dockerfile.ubuntu_18.04
@@ -2,31 +2,32 @@ FROM ubuntu:18.04
 LABEL author="James Cherry"
 LABEL maintainer="James Cherry <cherry@parallaxsw.com>"
 
-# install basics
+# Install basics
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-    apt-get install -y wget apt-utils git cmake gcc tcl-dev swig bison flex
+    apt-get install -y wget cmake gcc tcl-dev tcl-tclreadline libeigen3-dev swig bison flex
 
-# download CUDD
-RUN wget https://www.davidkebo.com/source/cudd_versions/cudd-3.0.0.tar.gz && \
+# Download CUDD
+RUN wget https://raw.githubusercontent.com/davidkebo/cudd/main/cudd_versions/cudd-3.0.0.tar.gz && \
     tar -xvf cudd-3.0.0.tar.gz && \
     rm cudd-3.0.0.tar.gz
 
-# install CUDD
+# Install CUDD
 RUN cd cudd-3.0.0 && \
     mkdir ../cudd && \
-    ./configure --prefix=$HOME/cudd && \
-    make && \
+    ./configure && \
+    make -j`nproc` && \
     make install
 
-# copy files and install OpenSTA
+# Copy files and install OpenSTA
 RUN mkdir OpenSTA
 COPY . OpenSTA
 RUN cd OpenSTA && \
+    rm -rf build && \
     mkdir build && \
     cd build && \
-    cmake .. -DCUDD=$HOME/cudd && \
-    make
+    cmake .. && \
+    make -j`nproc`
 
 # Run sta on entry
 ENTRYPOINT ["OpenSTA/app/sta"]

--- a/app/Main.cc
+++ b/app/Main.cc
@@ -19,7 +19,6 @@
 
 #include <stdio.h>
 #include <cstdlib>              // exit
-#include <filesystem>
 #include <tcl.h>
 #if TCL_READLINE
   #include <tclreadline.h>


### PR DESCRIPTION
Updates to enable Ubuntu 18.04 compatibility in Docker.

`app/Main.cc`:
- Remove `filesystem` (unused) which breaks GCC compatibility

`Dockerfile.ubuntu_18.04`:
- Remove `apt-utils` and `git` from dependencies (unused)
- Add `tcl-tclreadline` and `libeigen3-dev` (new dependencies)
- Update broken CUDD download link to GitHub version
- Fix CUDD install path and make with multiple cores