### PR TITLE
add cell footprint support & add it to equiv check

### DIFF
--- a/include/sta/EquivCells.hh
+++ b/include/sta/EquivCells.hh
@@ -73,4 +73,8 @@ bool
 equivCellSequentials(const LibertyCell *cell1,
 		     const LibertyCell *cell2);
 
+bool
+equivCellFootprints(const LibertyCell *cell1,
+                    const LibertyCell *cell2);
+
 } // namespace

--- a/include/sta/Liberty.hh
+++ b/include/sta/Liberty.hh
@@ -83,6 +83,8 @@ typedef Map<const char *, float, CharPtrLess> SupplyVoltageMap;
 typedef Map<const char *, LibertyPgPort*, CharPtrLess> LibertyPgPortMap;
 typedef Map<const char *, DriverWaveform*, CharPtrLess> DriverWaveformMap;
 typedef Vector<DcalcAnalysisPt*> DcalcAnalysisPtSeq;
+typedef int LibertyCellFootprintIndex;
+typedef Vector<const char *> LibertyCellFootprintSeq;
 
 enum class ClockGateType { none, latch_posedge, latch_negedge, other };
 
@@ -142,6 +144,7 @@ public:
   // Liberty cells that are buffers.
   LibertyCellSeq *buffers();
   LibertyCellSeq *inverters();
+  void addFootprint(const char *footprint);
 
   DelayModelType delayModelType() const { return delay_model_type_; }
   void setDelayModelType(DelayModelType type);
@@ -371,6 +374,7 @@ protected:
   SupplyVoltageMap supply_voltage_map_;
   LibertyCellSeq *buffers_;
   LibertyCellSeq *inverters_;
+  LibertyCellFootprintSeq footprints_;
   DriverWaveformMap driver_waveform_map_;
   // Unnamed driver waveform.
   DriverWaveform *driver_waveform_default_;
@@ -541,6 +545,8 @@ public:
   // for all the defined corners.
   static void checkLibertyCorners();
   void ensureVoltageWaveforms(const DcalcAnalysisPtSeq &dcalc_aps);
+  void setFootprintIndex(LibertyCellFootprintIndex footprint_index);
+  const char *footprint() const;
 
 protected:
   void addPort(ConcretePort *port);
@@ -631,6 +637,7 @@ protected:
   bool has_internal_ports_;
   bool have_voltage_waveforms_;
   std::mutex waveform_lock_;
+  LibertyCellFootprintIndex footprint_index_;
 
 private:
   friend class LibertyLibrary;

--- a/include/sta/Liberty.hh
+++ b/include/sta/Liberty.hh
@@ -83,8 +83,6 @@ typedef Map<const char *, float, CharPtrLess> SupplyVoltageMap;
 typedef Map<const char *, LibertyPgPort*, CharPtrLess> LibertyPgPortMap;
 typedef Map<const char *, DriverWaveform*, CharPtrLess> DriverWaveformMap;
 typedef Vector<DcalcAnalysisPt*> DcalcAnalysisPtSeq;
-typedef int LibertyCellFootprintIndex;
-typedef Vector<const char *> LibertyCellFootprintSeq;
 
 enum class ClockGateType { none, latch_posedge, latch_negedge, other };
 
@@ -144,7 +142,6 @@ public:
   // Liberty cells that are buffers.
   LibertyCellSeq *buffers();
   LibertyCellSeq *inverters();
-  void addFootprint(const char *footprint);
 
   DelayModelType delayModelType() const { return delay_model_type_; }
   void setDelayModelType(DelayModelType type);
@@ -374,7 +371,6 @@ protected:
   SupplyVoltageMap supply_voltage_map_;
   LibertyCellSeq *buffers_;
   LibertyCellSeq *inverters_;
-  LibertyCellFootprintSeq footprints_;
   DriverWaveformMap driver_waveform_map_;
   // Unnamed driver waveform.
   DriverWaveform *driver_waveform_default_;
@@ -545,8 +541,8 @@ public:
   // for all the defined corners.
   static void checkLibertyCorners();
   void ensureVoltageWaveforms(const DcalcAnalysisPtSeq &dcalc_aps);
-  void setFootprintIndex(LibertyCellFootprintIndex footprint_index);
   const char *footprint() const;
+  void setFootprint(const char *footprint);
 
 protected:
   void addPort(ConcretePort *port);
@@ -637,7 +633,7 @@ protected:
   bool has_internal_ports_;
   bool have_voltage_waveforms_;
   std::mutex waveform_lock_;
-  LibertyCellFootprintIndex footprint_index_;
+  const char *footprint_;
 
 private:
   friend class LibertyLibrary;

--- a/liberty/EquivCells.cc
+++ b/liberty/EquivCells.cc
@@ -530,7 +530,7 @@ bool
 equivCellFootprints(const LibertyCell *cell1,
                     const LibertyCell *cell2)
 {
-  return strcmp(cell1->footprint(), cell2->footprint()) == 0;
+  return stringEqIf(cell1->footprint(), cell2->footprint());
 }
 
 } // namespace

--- a/liberty/EquivCells.cc
+++ b/liberty/EquivCells.cc
@@ -325,7 +325,8 @@ equivCells(const LibertyCell *cell1,
     && equivCellPgPorts(cell1, cell2)
     && equivCellSequentials(cell1, cell2)
     && equivCellStatetables(cell1, cell2)
-    && equivCellTimingArcSets(cell1, cell2);
+    && equivCellTimingArcSets(cell1, cell2)
+    && equivCellFootprints(cell1, cell2);
 }
 
 bool
@@ -523,6 +524,13 @@ equivCellTimingArcSets(const LibertyCell *cell1,
     }
     return true;
   }
+}
+
+bool
+equivCellFootprints(const LibertyCell *cell1,
+                    const LibertyCell *cell2)
+{
+  return strcmp(cell1->footprint(), cell2->footprint()) == 0;
 }
 
 } // namespace

--- a/liberty/Liberty.cc
+++ b/liberty/Liberty.cc
@@ -128,6 +128,9 @@ LibertyLibrary::~LibertyLibrary()
   delete inverters_;
   driver_waveform_map_.deleteContents();
   delete driver_waveform_default_;
+
+  for (auto footprint : footprints_)
+    stringDelete(footprint);
 }
 
 LibertyCell *
@@ -179,6 +182,12 @@ LibertyLibrary::buffers()
     }
   }
   return buffers_;
+}
+
+void
+LibertyLibrary::addFootprint(const char *footprint)
+{
+  footprints_.push_back(stringCopy(footprint));
 }
 
 void
@@ -940,7 +949,8 @@ LibertyCell::LibertyCell(LibertyLibrary *library,
   leakage_power_(0.0),
   leakage_power_exists_(false),
   has_internal_ports_(false),
-  have_voltage_waveforms_(false)
+  have_voltage_waveforms_(false),
+  footprint_index_(-1)
 {
   liberty_cell_ = this;
 }
@@ -1987,6 +1997,21 @@ LibertyCell::ensureVoltageWaveforms(const DcalcAnalysisPtSeq &dcalc_aps)
       have_voltage_waveforms_ = true;
     }
   }
+}
+
+void
+LibertyCell::setFootprintIndex(LibertyCellFootprintIndex footprint_index)
+{
+  footprint_index_ = footprint_index;
+}
+
+const char*
+LibertyCell::footprint() const
+{
+  if (footprint_index_ != -1) {
+    return libertyLibrary()->footprints_[footprint_index_];
+  }
+  return "";
 }
 
 ////////////////////////////////////////////////////////////////

--- a/liberty/Liberty.cc
+++ b/liberty/Liberty.cc
@@ -128,9 +128,6 @@ LibertyLibrary::~LibertyLibrary()
   delete inverters_;
   driver_waveform_map_.deleteContents();
   delete driver_waveform_default_;
-
-  for (auto footprint : footprints_)
-    stringDelete(footprint);
 }
 
 LibertyCell *
@@ -182,12 +179,6 @@ LibertyLibrary::buffers()
     }
   }
   return buffers_;
-}
-
-void
-LibertyLibrary::addFootprint(const char *footprint)
-{
-  footprints_.push_back(stringCopy(footprint));
 }
 
 void
@@ -950,7 +941,7 @@ LibertyCell::LibertyCell(LibertyLibrary *library,
   leakage_power_exists_(false),
   has_internal_ports_(false),
   have_voltage_waveforms_(false),
-  footprint_index_(-1)
+  footprint_(nullptr)
 {
   liberty_cell_ = this;
 }
@@ -978,6 +969,8 @@ LibertyCell::~LibertyCell()
   ocv_derate_map_.deleteContents();
 
   pg_port_map_.deleteContents();
+
+  stringDelete(footprint_);
 }
 
 LibertyPort *
@@ -2000,18 +1993,18 @@ LibertyCell::ensureVoltageWaveforms(const DcalcAnalysisPtSeq &dcalc_aps)
 }
 
 void
-LibertyCell::setFootprintIndex(LibertyCellFootprintIndex footprint_index)
+LibertyCell::setFootprint(const char *footprint)
 {
-  footprint_index_ = footprint_index;
+  footprint_ = stringCopy(footprint);
 }
 
 const char*
 LibertyCell::footprint() const
 {
-  if (footprint_index_ != -1) {
-    return libertyLibrary()->footprints_[footprint_index_];
-  }
-  return "";
+  if (footprint_)
+    return footprint_;
+  else
+    return "";
 }
 
 ////////////////////////////////////////////////////////////////

--- a/liberty/Liberty.cc
+++ b/liberty/Liberty.cc
@@ -2001,10 +2001,7 @@ LibertyCell::setFootprint(const char *footprint)
 const char*
 LibertyCell::footprint() const
 {
-  if (footprint_)
-    return footprint_;
-  else
-    return "";
+  return footprint_;
 }
 
 ////////////////////////////////////////////////////////////////

--- a/liberty/LibertyReader.cc
+++ b/liberty/LibertyReader.cc
@@ -726,9 +726,6 @@ LibertyReader::endLibraryAttrs(LibertyGroup *group)
   if (missing_threshold)
     libError(1149, group, "Library %s is missing one or more thresholds.",
 	     library_->name());
-
-  for (auto [footprint, footprint_index] : footprint_index_map_)
-    stringDelete(footprint);
 }
 
 void
@@ -3074,19 +3071,8 @@ LibertyReader::visitCellFootprint(LibertyAttr *attr)
 {
   if (cell_) {
     const char *footprint = getAttrString(attr);
-    if (!footprint) {
-      return;
-    }
-    LibertyCellFootprintIndex footprint_index;
-    auto itr = footprint_index_map_.find(footprint);
-    if (itr != footprint_index_map_.end()) {
-      footprint_index = itr->second;
-    } else {
-      footprint_index = static_cast<int>(footprint_index_map_.size());
-      footprint_index_map_[stringCopy(footprint)] = footprint_index;
-      library()->addFootprint(stringCopy(footprint));
-    }
-    cell_->setFootprintIndex(footprint_index);
+    if (footprint)
+      cell_->setFootprint(stringCopy(footprint));
   }
 }
 

--- a/liberty/LibertyReader.cc
+++ b/liberty/LibertyReader.cc
@@ -310,6 +310,7 @@ LibertyReader::defineVisitors()
   defineAttrVisitor("switch_cell_type", &LibertyReader::visitSwitchCellType);
   defineAttrVisitor("interface_timing", &LibertyReader::visitInterfaceTiming);
   defineAttrVisitor("scaling_factors", &LibertyReader::visitScalingFactors);
+  defineAttrVisitor("cell_footprint", &LibertyReader::visitCellFootprint);
 
   // Pins
   defineGroupVisitor("pin", &LibertyReader::beginPin,&LibertyReader::endPin);
@@ -725,6 +726,9 @@ LibertyReader::endLibraryAttrs(LibertyGroup *group)
   if (missing_threshold)
     libError(1149, group, "Library %s is missing one or more thresholds.",
 	     library_->name());
+
+  for (auto [footprint, footprint_index] : footprint_index_map_)
+    stringDelete(footprint);
 }
 
 void
@@ -3062,6 +3066,27 @@ LibertyReader::visitClockGatingIntegratedCell(LibertyAttr *attr)
       else
 	cell_->setClockGateType(ClockGateType::other);
     }
+  }
+}
+
+void
+LibertyReader::visitCellFootprint(LibertyAttr *attr)
+{
+  if (cell_) {
+    const char *footprint = getAttrString(attr);
+    if (!footprint) {
+      return;
+    }
+    LibertyCellFootprintIndex footprint_index;
+    auto itr = footprint_index_map_.find(footprint);
+    if (itr != footprint_index_map_.end()) {
+      footprint_index = itr->second;
+    } else {
+      footprint_index = static_cast<int>(footprint_index_map_.size());
+      footprint_index_map_[stringCopy(footprint)] = footprint_index;
+      library()->addFootprint(stringCopy(footprint));
+    }
+    cell_->setFootprintIndex(footprint_index);
   }
 }
 

--- a/liberty/LibertyReaderPvt.hh
+++ b/liberty/LibertyReaderPvt.hh
@@ -65,8 +65,6 @@ typedef Vector<LeakagePowerGroup*> LeakagePowerGroupSeq;
 typedef void (LibertyPort::*LibertyPortBoolSetter)(bool value);
 typedef Vector<OutputWaveform*> OutputWaveformSeq;
 typedef vector<string> StdStringSeq;
-typedef Map<const char*, LibertyCellFootprintIndex,
-            CharPtrLess> LibertyCellFootprintIndexMap;
 
 class LibertyReader : public LibertyGroupVisitor
 {
@@ -666,7 +664,6 @@ protected:
   float reference_time_;
   bool reference_time_exists_;
   const char *driver_waveform_name_;
-  LibertyCellFootprintIndexMap footprint_index_map_;
 
   static constexpr char escape_ = '\\';
 

--- a/liberty/LibertyReaderPvt.hh
+++ b/liberty/LibertyReaderPvt.hh
@@ -65,6 +65,8 @@ typedef Vector<LeakagePowerGroup*> LeakagePowerGroupSeq;
 typedef void (LibertyPort::*LibertyPortBoolSetter)(bool value);
 typedef Vector<OutputWaveform*> OutputWaveformSeq;
 typedef vector<string> StdStringSeq;
+typedef Map<const char*, LibertyCellFootprintIndex,
+            CharPtrLess> LibertyCellFootprintIndexMap;
 
 class LibertyReader : public LibertyGroupVisitor
 {
@@ -205,6 +207,7 @@ public:
   virtual void visitInterfaceTiming(LibertyAttr *attr);
   virtual void visitScalingFactors(LibertyAttr *attr);
   virtual void visitCellLeakagePower(LibertyAttr *attr);
+  virtual void visitCellFootprint(LibertyAttr *attr);
 
   virtual void beginPin(LibertyGroup *group);
   virtual void endPin(LibertyGroup *group);
@@ -663,6 +666,7 @@ protected:
   float reference_time_;
   bool reference_time_exists_;
   const char *driver_waveform_name_;
+  LibertyCellFootprintIndexMap footprint_index_map_;
 
   static constexpr char escape_ = '\\';
 


### PR DESCRIPTION
This is to address some [Resizing Problems](https://github.com/The-OpenROAD-Project/OpenROAD/issues/5577) in OR. With this, RSZ won't swap cells that are functionally equivalent but non equivalent footprint wise.