### PR TITLE
add GitHub Action to build and run tests on macOS

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,23 @@
+name: tests
+on: [push]
+
+jobs:
+  macos:
+    runs-on: [macos-14]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - run: brew bundle
+      - run: |
+          cmake -S . -B build
+
+          cd build
+          make
+          sudo make install
+      - run: |
+          cd test
+          ./regression || {
+            [ -f results/diffs ] && cat results/diffs
+          }

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ doc/._Sta.docx
 test/results
 # ngspice turd
 test/b3v3_1check.log
+
+Brewfile.lock.json

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,9 @@
+brew "bison"
+brew "cmake"
+brew "eigen"
+brew "flex"
+brew "swig"
+brew "tcl-tk"
+
+tap "mht208/formal"
+brew "mht208/formal/cudd"


### PR DESCRIPTION
I was interested in learning more about OpenSTA [on my macOS] and thought it'd be helpful to add a GitHub Action to build and run tests on macOS. An example of the run is available from https://github.com/gnawhleinad/OpenSTA/actions/runs/10754768096.

From the `Dockerfile.*`s, it looks like there's a dependency to `cudd` from https://github.com/davidkebo/cudd. I'm using `brew` and opted for [`mht208/homebrew-formula:cudd.rb`](https://github.com/mht208/homebrew-formal/blob/master/cudd.rb)[^1]. If `@parallaxsw` is :cool: and to keep things self-contained, a [custom tap](https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap) _could_ be added to this repository.

[^1]: There were [two public formulas](https://github.com/search?q=https%3A%2F%2Fgithub.com%2Fivmai%2Fcudd%2Farchive%2Fcudd-3.0.0.tar.gz+language%3ARuby&type=code&l=Ruby) and I arbitrarily chose `mht208`'s. The other is [`SRI-CSL/homebrew-sri-csl:cudd.rb`](https://github.com/SRI-CSL/homebrew-sri-csl/blob/master/Formula/cudd.rb).

