### PR TITLE
build and run tests on each `Dockerfile.*`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,21 @@
+name: tests
+on: [push]
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [centos7, ubuntu_18.04]
+
+    runs-on: [ubuntu-24.04]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - run: |
+          cp Dockerfile.${{ matrix.os }} Dockerfile
+          docker build --tag sta-${{ matrix.os }} .
+      - run: |
+          docker run --entrypoint /OpenSTA/test/regression --tty --rm sta-${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ doc/._Sta.docx
 test/results
 # ngspice turd
 test/b3v3_1check.log
+
+Dockerfile


### PR DESCRIPTION
Irrespective of https://github.com/parallaxsw/OpenSTA/pull/84, this pull request adds GitHub Action tests to build and run from the `Dockerfile`s in this repository.

It looks like it's both systems are failing on `liberty_arcs_one2one`...?