### PR TITLE
Remove the footprint check from equivCells

### DIFF
--- a/include/sta/EquivCells.hh
+++ b/include/sta/EquivCells.hh
@@ -73,8 +73,4 @@ bool
 equivCellSequentials(const LibertyCell *cell1,
 		     const LibertyCell *cell2);
 
-bool
-equivCellFootprints(const LibertyCell *cell1,
-                    const LibertyCell *cell2);
-
 } // namespace

--- a/liberty/EquivCells.cc
+++ b/liberty/EquivCells.cc
@@ -325,8 +325,7 @@ equivCells(const LibertyCell *cell1,
     && equivCellPgPorts(cell1, cell2)
     && equivCellSequentials(cell1, cell2)
     && equivCellStatetables(cell1, cell2)
-    && equivCellTimingArcSets(cell1, cell2)
-    && equivCellFootprints(cell1, cell2);
+    && equivCellTimingArcSets(cell1, cell2);
 }
 
 bool
@@ -524,13 +523,6 @@ equivCellTimingArcSets(const LibertyCell *cell1,
     }
     return true;
   }
-}
-
-bool
-equivCellFootprints(const LibertyCell *cell1,
-                    const LibertyCell *cell2)
-{
-  return stringEqIf(cell1->footprint(), cell2->footprint());
 }
 
 } // namespace


### PR DESCRIPTION
This check will become part of OpenROAD and not sta to allow for more flexibility and augmentation with physical data.