### PR TITLE
Bugfix: SDC square bracket escaping on single-bit input ports

### DIFF
--- a/network/SdcNetwork.cc
+++ b/network/SdcNetwork.cc
@@ -664,6 +664,12 @@ SdcNetwork::findPort(const Cell *cell,
 	port = network_->findPort(cell, escaped2.c_str());
       }
     }
+    else {
+      // Try escaping pin name
+      string escaped2;
+      string escaped_pin_name = escapeBrackets(name, this);
+      port = network_->findPort(cell, escaped_pin_name.c_str());
+    }
   }
   return port;
 }
@@ -693,6 +699,12 @@ SdcNetwork::findPortsMatching(const Cell *cell,
 	PatternMatch escaped_pattern2(escaped_name.c_str(), pattern);
 	matches = network_->findPortsMatching(cell, &escaped_pattern2);
       }
+    }
+    if (!is_bus && matches.empty()) {
+      // Try escaping pattern
+      string escaped_name = escapeBrackets(pattern->pattern(), this);
+      PatternMatch escaped_pattern2(escaped_name.c_str(), pattern);
+      matches = network_->findPortsMatching(cell, &escaped_pattern2);
     }
   }
   return matches;
@@ -896,6 +908,12 @@ SdcNetwork::findPin(const Instance *instance,
         stringPrint(escaped2, "%s[%d]", escaped_bus_name.c_str(), index);
 	pin = network_->findPin(instance, escaped2.c_str());
       }
+    }
+    else {
+      // Try escaping port name
+      string escaped2;
+      string escaped_port_name = escapeBrackets(port_name, this);
+      pin = network_->findPin(instance, escaped_port_name.c_str());
     }
   }
   return pin;

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -126,6 +126,7 @@ record_sta_tests {
   verilog_attribute
   liberty_arcs_one2one
   get_filter
+  verilog_square_bracket
 }
 
 define_test_group fast [group_tests all]

--- a/test/verilog_square_bracket.tcl
+++ b/test/verilog_square_bracket.tcl
@@ -1,0 +1,6 @@
+# Read in design and libraries
+read_liberty asap7_small.lib.gz
+read_verilog verilog_square_bracket.v
+link_design square_bracket
+create_clock -period 1 -name vclk
+set_input_delay -clock vclk 1 [all_inputs]

--- a/test/verilog_square_bracket.tcl
+++ b/test/verilog_square_bracket.tcl
@@ -1,4 +1,4 @@
-# Read in design and libraries
+# Verilog input pin with square brackets in middle of pin name
 read_liberty asap7_small.lib.gz
 read_verilog verilog_square_bracket.v
 link_design square_bracket

--- a/test/verilog_square_bracket.v
+++ b/test/verilog_square_bracket.v
@@ -1,0 +1,15 @@
+module square_bracket (
+  \in[0].test ,
+  \out[0].test 
+);
+  input \in[0].test ;
+  wire \in[0].test ;
+
+  output \out[0].test ;
+  wire \out[0].test ;
+
+  BUFx2_ASAP7_75t_R inst0 (
+    .A( \in[0].test ),
+    .Y( \out[0].test )
+  );
+endmodule


### PR DESCRIPTION
I've included a minimal test case where OpenSTA fails to annotate input delays on a valid netlist (try `verilog_square_bracket` test). It's a bit of a corner case, but I was ultimately able to isolate and resolve the problem.

It's related to naming of ports in SDC when square brackets exist in the middle of the port names. These square brackets need to be escaped. There is some code that already does this for bus ports, but that code doesn't handle single-bit ports.

I've essentially replicated all the places I found the escape logic to also handle single-bit port scenarios, and with that code added, the test case passes.