### PR TITLE
Fixes constant integer verilog parsing

### DIFF
--- a/test/verilog_attribute.v
+++ b/test/verilog_attribute.v
@@ -11,6 +11,7 @@ module counter(clk, reset, in, out);
   (* src = "synthesis/tests/counter.v:18.14-18.19" *)
   input reset;
   input in;
+  (* bottom_bound = 1'sh0 *)
   (* src = "synthesis/tests/counter.v:22.3-28.6", attr1 = "test_attr1", attr2 = "test_attr2" *)
   sky130_fd_sc_hd__dfrtp_1 _1415_ (
     .CLK(clk),

--- a/verilog/VerilogLex.ll
+++ b/verilog/VerilogLex.ll
@@ -76,22 +76,22 @@ ID_TOKEN {ID_ESCAPED_TOKEN}|{ID_ALPHA_TOKEN}
 	}
 }
 
-{SIGN}?{UNSIGNED_NUMBER}?"'"[bB][01_xz]+ {
+{SIGN}?{UNSIGNED_NUMBER}?"'"[sS]?[bB][01_xz]+ {
   VerilogParse_lval.constant = sta::stringCopy(VerilogLex_text);
   return CONSTANT;
 }
 
-{SIGN}?{UNSIGNED_NUMBER}?"'"[oO][0-7_xz]+ {
+{SIGN}?{UNSIGNED_NUMBER}?"'"[sS]?[oO][0-7_xz]+ {
   VerilogParse_lval.constant = sta::stringCopy(VerilogLex_text);
   return CONSTANT;
 }
 
-{SIGN}?{UNSIGNED_NUMBER}?"'"[dD][0-9_]+ {
+{SIGN}?{UNSIGNED_NUMBER}?"'"[sS]?[dD][0-9_]+ {
   VerilogParse_lval.constant = sta::stringCopy(VerilogLex_text);
   return CONSTANT;
 }
 
-{SIGN}?{UNSIGNED_NUMBER}?"'"[hH][0-9a-fA-F_xz]+ {
+{SIGN}?{UNSIGNED_NUMBER}?"'"[sS]?[hH][0-9a-fA-F_xz]+ {
   VerilogParse_lval.constant = sta::stringCopy(VerilogLex_text);
   return CONSTANT;
 }


### PR DESCRIPTION
Fixes parsing attributes of the form

```systemverilog
  (* bottom_bound = 1'sh0 *)
  sky130_fd_sc_hd__dfrtp_1 _1415_ (
    .CLK(clk),
    .D(in),
    .Q(out),
    .RESET_B(reset)
  );
```

In particular "supporting" the signed indicator.