### PR TITLE
Hierarchical Verilog writer repairs

### DIFF
--- a/include/sta/Vector.hh
+++ b/include/sta/Vector.hh
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <vector>
+#include <deque>
 #include <algorithm>
 
 namespace sta {
@@ -126,7 +127,7 @@ sort(Vector<OBJ> &seq, SortCmp cmp)
   std::stable_sort(seq.begin(), seq.end(), cmp);
 }
 
-template <class OBJ, class SortCmp>
+  template <class OBJ, class SortCmp>
 void
 sort(Vector<OBJ> *seq, SortCmp cmp)
 {
@@ -135,4 +136,23 @@ sort(Vector<OBJ> *seq, SortCmp cmp)
   std::stable_sort(seq->begin(), seq->end(), cmp);
 }
 
+
+template <class OBJ, class SortCmp>
+void
+sort(std::deque<OBJ> *seq, SortCmp cmp)
+{
+  // For some strange reason std::sort goes off into never never land
+  // when optimization is turned on in gcc.
+  std::stable_sort(seq->begin(), seq->end(), cmp);
+}
+
+template <class OBJ, class SortCmp>
+void
+sort(std::deque<OBJ> &seq, SortCmp cmp)
+{
+  // For some strange reason std::sort goes off into never never land
+  // when optimization is turned on in gcc.
+  std::stable_sort(seq.begin(), seq.end(), cmp);
+}
+  
 } // namespace sta

--- a/verilog/VerilogWriter.cc
+++ b/verilog/VerilogWriter.cc
@@ -18,7 +18,7 @@
 
 #include <cstdlib>
 #include <algorithm>
-
+#include <deque>
 #include "Error.hh"
 #include "Liberty.hh"
 #include "PortDirection.hh"
@@ -75,7 +75,7 @@ protected:
   Network *network_;
 
   CellSet written_cells_;
-  Vector<Instance*> pending_children_;
+  std::deque<Instance*> pending_children_;  
   int unconnected_net_index_;
 };
 


### PR DESCRIPTION
Hi,
We observed some strange behaviour with the iterators on pending_children_ during writeModule (we saw a seg fault). Matt suggested replacing the vector with a deque which seems to do the trick. I am not quite sure why the original code failed (looked ok to me) but the problem seemed to occur when at the last element of the pending_children_ and then the recursive call adding another element.
The fix includes the replacement of the pending_children_  Vector -> deque in writeModule in VerilogWriter.cc
Also, I added a sort for deque in Vector.hh (am guessing there might usefully be a new header file wrapper for deque).
