### PR TITLE
BUGFIX: Adjust Liberty parser to accept groups with colons

### DIFF
--- a/liberty/LibertyParse.yy
+++ b/liberty/LibertyParse.yy
@@ -50,7 +50,7 @@ int LibertyLex_lex();
 %token <string> STRING KEYWORD
 
 %type <stmt> statement complex_attr simple_attr variable group file
-%type <attr_values> attr_values
+%type <attr_values> attr_values colon_expr
 %type <attr_value> attr_value
 %type <string> string expr expr_term expr_term1 volt_expr
 %type <line> line
@@ -83,6 +83,10 @@ group:
 	'}' semi_opt
 	{ $$ = sta::libertyGroupEnd(); }
 |	KEYWORD '(' attr_values ')' line '{'
+	{ sta::libertyGroupBegin($1, $3, $5); }
+	statements '}' semi_opt
+	{ $$ = sta::libertyGroupEnd(); }
+|	KEYWORD '(' colon_expr ')' line '{'
 	{ sta::libertyGroupBegin($1, $3, $5); }
 	statements '}' semi_opt
 	{ $$ = sta::libertyGroupEnd(); }
@@ -150,6 +154,14 @@ attr_value:
 	{ $$ = sta::makeLibertyStringAttrValue($1); }
 |	volt_expr
 	{ $$ = sta::makeLibertyStringAttrValue($1); }
+
+/* Colon expressions are normal exprs with a ':' separator. */
+colon_expr:
+	expr ':' expr
+	{ char *expr_str = sta::stringPrint("%s:%s", $1, $3);
+	  $$ = new sta::LibertyAttrValueSeq;
+	  $$->push_back(sta::makeLibertyStringAttrValue(expr_str));
+	}
 	;
 
 /* Voltage expressions are ignored. */

--- a/liberty/LibertyParse.yy
+++ b/liberty/LibertyParse.yy
@@ -119,6 +119,9 @@ complex_attr:
 |	KEYWORD '(' attr_values ')' line semi_opt
 	{ $$ = sta::makeLibertyComplexAttr($1, $3, $5); }
 	;
+|	KEYWORD '(' colon_expr ')' line semi_opt
+	{ $$ = sta::makeLibertyComplexAttr($1, $3, $5); }
+	;
 
 attr_values:
 	attr_value

--- a/test/ccs_input_ccb_colon.lib
+++ b/test/ccs_input_ccb_colon.lib
@@ -1,0 +1,51 @@
+library (ccs_input_ccb_colon) {
+  delay_model : "table_lookup";
+  simulation : false;
+  capacitive_load_unit (1,pF);
+  leakage_power_unit : "1pW";
+  current_unit : "1A";
+  pulling_resistance_unit : "1kohm";
+  time_unit : "1ns";
+  voltage_unit : "1v";
+  library_features : "report_delay_calculation";
+  input_threshold_pct_rise : 50;
+  input_threshold_pct_fall : 50;
+  output_threshold_pct_rise : 50;
+  output_threshold_pct_fall : 50;
+  slew_lower_threshold_pct_rise : 30;
+  slew_lower_threshold_pct_fall : 30;
+  slew_upper_threshold_pct_rise : 70;
+  slew_upper_threshold_pct_fall : 70;
+  slew_derate_from_library : 1.0;
+  nom_process : 1.0;
+  nom_temperature : 85.0;
+  nom_voltage : 0.75;
+
+  cell(ccs_input_ccb_colon) { 
+    sensitization_master : sensitization_3pins ; 
+    area : 0.1 ; 
+    dont_touch : true ; 
+    dont_use : true ; 
+
+    pin(A) { 
+      capacitance : 0.0001 ; 
+      direction : input ; 
+      driver_waveform_rise : "driver_waveform_default_rise" ; 
+      driver_waveform_fall : "driver_waveform_default_fall" ; 
+      fall_capacitance : 0.0001 ; 
+      input_voltage : default ; 
+      max_transition : 0.1 ; 
+      related_ground_pin : VSS ; 
+      related_power_pin : VDD ; 
+      rise_capacitance : 0.0001 ; 
+
+      input_ccb(ccs_input_ccb_colon:a) { 
+        is_needed : true ; 
+        is_inverting : true ; 
+        miller_cap_fall : 0.0001 ; 
+        miller_cap_rise : 1e-05 ; 
+        stage_type : both ; 
+      }
+    }
+  }
+}

--- a/test/ccs_input_ccb_colon.lib
+++ b/test/ccs_input_ccb_colon.lib
@@ -38,6 +38,7 @@ library (ccs_input_ccb_colon) {
       related_ground_pin : VSS ; 
       related_power_pin : VDD ; 
       rise_capacitance : 0.0001 ; 
+      active_input_ccb(ccs_input_ccb_colon:ck);
 
       input_ccb(ccs_input_ccb_colon:a) { 
         is_needed : true ; 

--- a/test/ccs_input_ccb_colon.ok
+++ b/test/ccs_input_ccb_colon.ok
@@ -1,0 +1,1 @@
+ccs_input_ccb_colon.lib read

--- a/test/ccs_input_ccb_colon.tcl
+++ b/test/ccs_input_ccb_colon.tcl
@@ -1,0 +1,3 @@
+# test ccsn with input_ccb having a colon in group name
+read_liberty ccs_input_ccb_colon.lib
+puts "ccs_input_ccb_colon.lib read"

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -130,6 +130,7 @@ record_sta_tests {
   get_noargs
   get_objrefs
   report_checks_src_attr
+  ccs_input_ccb_colon
 }
 
 define_test_group fast [group_tests all]


### PR DESCRIPTION
See issue #114 for more details. Quick (conservative) fix by adding more permissiveness on the group name with `colon_expr` in `liberty/LibertyParse.yy`. Also added the testcase in #114 to check that parsing of the Liberty file doesn't fail.