### PR TITLE
Add <cstdlib> header for later cpp compatibility.

### DIFF
--- a/dcalc/FindRoot.cc
+++ b/dcalc/FindRoot.cc
@@ -17,6 +17,7 @@
 #include "FindRoot.hh"
 
 #include <algorithm> // abs
+#include <cstdlib> // abs for C++11 
 
 namespace sta {
 

--- a/dcalc/FindRoot.cc
+++ b/dcalc/FindRoot.cc
@@ -16,8 +16,7 @@
 
 #include "FindRoot.hh"
 
-#include <algorithm> // abs
-#include <cstdlib> // abs for C++11 
+#include <cmath> // abs
 
 namespace sta {
 

--- a/util/StringUtil.cc
+++ b/util/StringUtil.cc
@@ -19,7 +19,7 @@
 #include <limits>
 #include <cctype>
 #include <cstdio>
-#include <cstdlib>
+#include <cstdlib> // exit
 #include <array>
 
 #include "Machine.hh"

--- a/util/StringUtil.cc
+++ b/util/StringUtil.cc
@@ -19,6 +19,7 @@
 #include <limits>
 #include <cctype>
 #include <cstdio>
+#include <cstdlib>
 #include <array>
 
 #include "Machine.hh"


### PR DESCRIPTION
std::abs has been moved to <cstdlib> in later versions of the standard.

https://en.cppreference.com/w/cpp/numeric/math/abs