### PR TITLE
Cache clock domains in check slew limits

### DIFF
--- a/search/CheckSlewLimits.cc
+++ b/search/CheckSlewLimits.cc
@@ -471,4 +471,6 @@ CheckSlewLimits::ClockDomains::clear()
   Super::clear();
 }
 
+thread_local CheckSlewLimits::ClockDomains CheckSlewLimits::clock_domains_;
+
 } // namespace

--- a/search/CheckSlewLimits.cc
+++ b/search/CheckSlewLimits.cc
@@ -185,14 +185,14 @@ CheckSlewLimits::checkSlews1(Vertex *vertex,
 // Return the tightest limit.
 void
 CheckSlewLimits::findLimit0(const Pin *pin,
-                            const Vertex *vertex,
-                            const Corner *corner,
-                            const RiseFall *rf,
-                            const MinMax *min_max,
-                            bool check_clks,
-                            // Return values.
-                            float &limit,
-                            bool &exists) const
+			   const Vertex *vertex,
+                           const Corner *corner,
+			   const RiseFall *rf,
+			   const MinMax *min_max,
+			   bool check_clks,
+			   // Return values.
+			   float &limit,
+			   bool &exists) const
 {
   const Network *network = sta_->network();
   Sdc *sdc = sta_->sdc();
@@ -351,16 +351,16 @@ CheckSlewLimits::clockDomains(const Vertex *vertex,
 
 void
 CheckSlewLimits::checkSlew0(Vertex *vertex,
-                            const Corner *corner,
-                            const RiseFall *rf,
-                            const MinMax *min_max,
-                            float limit,
-                            // Return values.
-                            const Corner *&corner1,
-                            const RiseFall *&rf1,
-                            Slew &slew1,
-                            float &slack1,
-                            float &limit1) const
+			   const Corner *corner,
+			   const RiseFall *rf,
+			   const MinMax *min_max,
+			   float limit,
+			   // Return values.
+			   const Corner *&corner1,
+			   const RiseFall *&rf1,
+			   Slew &slew1,
+			   float &slack1,
+			   float &limit1) const
 {
   const DcalcAnalysisPt *dcalc_ap = corner->findDcalcAnalysisPt(min_max);
   Slew slew = sta_->graph()->slew(vertex, rf, dcalc_ap->index());
@@ -429,11 +429,11 @@ CheckSlewLimits::checkSlewLimits0(const Net *net,
 
 void
 CheckSlewLimits::checkSlewLimits0(const Instance *inst,
-                                  bool violators,
-                                  const Corner *corner,
-                                  const MinMax *min_max,
-                                  PinSeq &slew_pins,
-                                  float &min_slack)
+                                 bool violators,
+                                 const Corner *corner,
+                                 const MinMax *min_max,
+                                 PinSeq &slew_pins,
+                                 float &min_slack)
 {
   const Network *network = sta_->network();
   InstancePinIterator *pin_iter = network->pinIterator(inst);

--- a/search/CheckSlewLimits.hh
+++ b/search/CheckSlewLimits.hh
@@ -58,6 +58,8 @@ public:
                  // Return values.
                  float &limit,
                  bool &exists) const;
+  void disconnectPinBefore(const Pin* pin) const;
+  static void setClockDomainsCanReset(bool can_reset = true);
 
 protected:
   void checkSlew0(const Pin *pin,
@@ -144,6 +146,10 @@ private:
     using Super = std::unordered_map<const Vertex*, ClockSet*>;
     ClockDomains() = default;
     ~ClockDomains();
+    void reset();
+    void remove(const Vertex* v);
+    bool can_reset = true;
+  protected:
     void clear();
   };
   static thread_local ClockDomains clock_domains_;

--- a/search/CheckSlewLimits.hh
+++ b/search/CheckSlewLimits.hh
@@ -103,37 +103,37 @@ protected:
 		   float &limit1,
 		   float &slack1) const;
   void checkSlew0(Vertex *vertex,
-                  const Corner *corner1,
-                  const RiseFall *rf1,
-                  const MinMax *min_max,
-                  float limit1,
-                  // Return values.
-                  const Corner *&corner,
-                  const RiseFall *&rf,
-                  Slew &slew,
-                  float &slack,
-                  float &limit) const;
+		 const Corner *corner1,
+		 const RiseFall *rf1,
+		 const MinMax *min_max,
+		 float limit1,
+		 // Return values.
+		 const Corner *&corner,
+		 const RiseFall *&rf,
+		 Slew &slew,
+		 float &slack,
+		 float &limit) const;
   void findLimit0(const Pin *pin,
-                  const Vertex *vertex,
-                  const Corner *corner,
-                  const RiseFall *rf,
-                  const MinMax *min_max,
-                  bool check_clks,
-                  // Return values.
-                  float &limit,
-                  bool &limit_exists) const;
+		 const Vertex *vertex,
+                 const Corner *corner,
+		 const RiseFall *rf,
+		 const MinMax *min_max,
+		 bool check_clks,
+		 // Return values.
+		 float &limit,
+		 bool &limit_exists) const;
   void checkSlewLimits0(const Instance *inst,
-                        bool violators,
-                        const Corner *corner,
-                        const MinMax *min_max,
-                        PinSeq &slew_pins,
-                        float &min_slack);
+                       bool violators,
+                       const Corner *corner,
+                       const MinMax *min_max,
+                       PinSeq &slew_pins,
+                       float &min_slack);
   void checkSlewLimits0(const Pin *pin,
-                        bool violators,
-                        const Corner *corner,
-                        const MinMax *min_max,
-                        PinSeq &slew_pins,
-                        float &min_slack);
+                       bool violators,
+                       const Corner *corner,
+                       const MinMax *min_max,
+                       PinSeq &slew_pins,
+                       float &min_slack);
   void clockDomains(const Vertex *vertex,
 		    // Return value.
 		    ClockSet &clks) const;

--- a/search/CheckSlewLimits.hh
+++ b/search/CheckSlewLimits.hh
@@ -60,6 +60,26 @@ public:
                  bool &exists) const;
 
 protected:
+  void checkSlew0(const Pin *pin,
+                  const Corner *corner,
+                  const MinMax *min_max,
+                  bool check_clks,
+                  // Return values.
+                  // Corner is nullptr for no slew limit.
+                  const Corner *&corner1,
+                  const RiseFall *&rf,
+                  Slew &slew,
+                  float &limit,
+                  float &slack) const;
+  PinSeq checkSlewLimits0(const Net *net,
+                          bool violators,
+                          const Corner *corner,
+                          const MinMax *min_max);
+  void findLimit0(const LibertyPort *port,
+                  const Corner *corner,
+                  const MinMax *min_max,
+                  float &limit,
+                  bool &exists) const;
   void checkSlews1(const Pin *pin,
 		   const Corner *corner,
 		   const MinMax *min_max,
@@ -80,43 +100,53 @@ protected:
 		   Slew &slew1,
 		   float &limit1,
 		   float &slack1) const;
-  void checkSlew(Vertex *vertex,
-		 const Corner *corner1,
-		 const RiseFall *rf1,
-		 const MinMax *min_max,
-		 float limit1,
-		 // Return values.
-		 const Corner *&corner,
-		 const RiseFall *&rf,
-		 Slew &slew,
-		 float &slack,
-		 float &limit) const;
-  void findLimit(const Pin *pin,
-		 const Vertex *vertex,
-                 const Corner *corner,
-		 const RiseFall *rf,
-		 const MinMax *min_max,
-		 bool check_clks,
-		 // Return values.
-		 float &limit,
-		 bool &limit_exists) const;
-  void checkSlewLimits(const Instance *inst,
-                       bool violators,
-                       const Corner *corner,
-                       const MinMax *min_max,
-                       PinSeq &slew_pins,
-                       float &min_slack);
-  void checkSlewLimits(const Pin *pin,
-                       bool violators,
-                       const Corner *corner,
-                       const MinMax *min_max,
-                       PinSeq &slew_pins,
-                       float &min_slack);
+  void checkSlew0(Vertex *vertex,
+                  const Corner *corner1,
+                  const RiseFall *rf1,
+                  const MinMax *min_max,
+                  float limit1,
+                  // Return values.
+                  const Corner *&corner,
+                  const RiseFall *&rf,
+                  Slew &slew,
+                  float &slack,
+                  float &limit) const;
+  void findLimit0(const Pin *pin,
+                  const Vertex *vertex,
+                  const Corner *corner,
+                  const RiseFall *rf,
+                  const MinMax *min_max,
+                  bool check_clks,
+                  // Return values.
+                  float &limit,
+                  bool &limit_exists) const;
+  void checkSlewLimits0(const Instance *inst,
+                        bool violators,
+                        const Corner *corner,
+                        const MinMax *min_max,
+                        PinSeq &slew_pins,
+                        float &min_slack);
+  void checkSlewLimits0(const Pin *pin,
+                        bool violators,
+                        const Corner *corner,
+                        const MinMax *min_max,
+                        PinSeq &slew_pins,
+                        float &min_slack);
   void clockDomains(const Vertex *vertex,
 		    // Return value.
 		    ClockSet &clks) const;
 
   const StaState *sta_;
+
+private:
+  class ClockDomains : public std::unordered_map<const Vertex*, ClockSet*> {
+  public:
+    using Super = std::unordered_map<const Vertex*, ClockSet*>;
+    ClockDomains() = default;
+    ~ClockDomains();
+    void clear();
+  };
+  mutable ClockDomains clock_domains_;
 };
 
 } // namespace

--- a/search/CheckSlewLimits.hh
+++ b/search/CheckSlewLimits.hh
@@ -146,7 +146,7 @@ private:
     ~ClockDomains();
     void clear();
   };
-  mutable ClockDomains clock_domains_;
+  static thread_local ClockDomains clock_domains_;
 };
 
 } // namespace

--- a/search/Sta.cc
+++ b/search/Sta.cc
@@ -4431,6 +4431,7 @@ Sta::disconnectPinBefore(const Pin *pin)
       }
     }
   }
+  check_slew_limits_->disconnectPinBefore(pin);
 }
 
 void


### PR DESCRIPTION
------

### Background

In a design with 200k components and processing 8 corners at the same time, I encountered a performance problem.

Specifically, **Sta::checkSlewLimits** was very slow in this case. The problem can be located in the call to **clockDomains** in **sta::CheckSlewLimits::findLimit**, which seems to take time **quadratic** to the number of corners.

When **CheckSlewLimits::checkSlewLimits** is using **nullptr** as parameter passed to corner, the inner function call **CheckSlewLimits::checkSlew** will do **CheckSlewLimits::checkSlew1** for all corners. **CheckSlewLimits::checkSlew1** will call **CheckSlewLimits::findLimit** which will call **CheckSlewLimits::clockDomains**. **CheckSlewLimits::clockDomains** will do **VertexPathIterator path_iter(const_cast<Vertex*>(vertex), sta_);** **VertexPathIterator::findNext** will call **arrival_iter_.hasNext()**.

------

### This PR makes the following attempts

- Add a cache for **clockDomains** to **sta::CheckSlewLimits**

  This cache will be cleared each time the **sta::CheckSlewLimits** public function is called.

- Add an option to stop clearing all caches automatically and only clear the corresponding vertex when the pin is disconnected

  ```c++
  sta::CheckSlewLimits::setClockDomainsCanReset(true/false);
  ```

  **The above method can prevent the cache from being completely cleared. However, it is necessary to ensure that the changes during the process will not modify the existing vertex's clock.**

------

Before the change, Sta::checkSlewLimits took about 48 minutes for this case, and about 6 minutes after the change. If the second option is enabled, it will be even faster.

In addition, before this change, I tried 22 corners in the same design, and Sta::checkSlewLimits took about 10 hours plus.

------