### PR TITLE
Add more allowed characters for RHS of filter expr: `\`, `/`, `$`, `[`, `]`

### DIFF
--- a/sdc/Sdc.tcl
+++ b/sdc/Sdc.tcl
@@ -408,7 +408,7 @@ proc current_design { {design ""} } {
 
 # Generic get_* filter.
 proc filter_objs { filter objects filter_function object_type } {
-  set filter_regexp1 {@?([a-zA-Z_]+) *((==|!=|=~|!~) *([0-9a-zA-Z_\*]+))?}
+  set filter_regexp1 {@?([a-zA-Z_]+) *((==|!=|=~|!~) *([0-9a-zA-Z_\\/$\[\]*]+))?}
   set filter_or_regexp "($filter_regexp1) *\\|\\| *($filter_regexp1)"
   set filter_and_regexp "($filter_regexp1) *&& *($filter_regexp1)"
   set filtered_objects {}


### PR DESCRIPTION
**Motivation:** filter name matching is not permissive enough to work with hierarchical full names containing `/`. I realized that a couple more special characters should be allowed on the RHS, so I updated the regex to allow them.

Let me know if I need to add formal test cases for this.