### PR TITLE
Apply incremental tolerance to wire slews

### DIFF
--- a/include/sta/GraphDelayCalc.hh
+++ b/include/sta/GraphDelayCalc.hh
@@ -217,7 +217,7 @@ protected:
                          ArcDelay &gate_delay,
                          Slew &gate_slew,
                          const DcalcAnalysisPt *dcalc_ap);
-  bool annotateLoadDelays(Vertex *drvr_vertex,
+  void annotateLoadDelays(Vertex *drvr_vertex,
                           const RiseFall *drvr_rf,
                           ArcDcalcResult &dcalc_result,
                           LoadPinIndexMap &load_pin_index_map,


### PR DESCRIPTION
The attached patch saves much of the delay recomputation that happens inside OpenROAD's `repair_timing` command. I've observed any instances touched cause a full recomputation of the output cone.

See the details in the patch -- by applying the incremental delay tolerance to load pin slews most of the recomputation is avoided. In the end this cuts repair_timing runtime on sky130hd/ibex post cts from 170 s to 41 s even if the tolerance is kept at zero (just because it avoids propagation when the slew is exactly the same).

The repair results were identical on the test cases I tried, which gives me some confidence in the patch, but I expect it needs careful review or a rewrite.

Cc @maliberty @QuantamHD @phsauter