### PR TITLE
Adds error message to prevent segfault

### DIFF
--- a/search/Sta.cc
+++ b/search/Sta.cc
@@ -5600,6 +5600,9 @@ Sta::writeTimingModel(const char *lib_name,
                       const char *filename,
                       const Corner *corner)
 {
+  if (network()->defaultLibertyLibrary() == nullptr) {
+    report_->error(2141, "No liberty libraries found.");
+  }
   LibertyLibrary *library = makeTimingModel(lib_name, cell_name, filename,
                                             corner, this);
   writeLiberty(library, filename, this);


### PR DESCRIPTION
make_timing_model segfaults if no liberty library call was run before calling it. This add a helpful error message instead.