### PR TITLE
Fix newline on escaped verilog names

### DIFF
--- a/network/ParseBus.cc
+++ b/network/ParseBus.cc
@@ -87,6 +87,10 @@ parseBusName(const char *name,
         is_bus = true;
 	size_t bus_name_len = left - name;
 	bus_name.append(name, bus_name_len);
+	// Remove trailing newlines from bus name.
+	size_t pos;
+	while (((pos=bus_name.find('\n')) != string::npos))
+	  bus_name.erase(pos, 1);
 	// Simple bus subscript.
 	index = atoi(left + 1);
       }

--- a/network/ParseBus.cc
+++ b/network/ParseBus.cc
@@ -88,9 +88,7 @@ parseBusName(const char *name,
 	size_t bus_name_len = left - name;
 	bus_name.append(name, bus_name_len);
 	// Remove trailing newlines from bus name.
-	size_t pos;
-	while (((pos=bus_name.find('\n')) != string::npos))
-	  bus_name.erase(pos, 1);
+	bus_name = bus_name.substr(0, bus_name.rfind('\n'));
 	// Simple bus subscript.
 	index = atoi(left + 1);
       }

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -133,6 +133,7 @@ record_sta_tests {
   get_lib_pins_of_objects
   report_checks_src_attr
   liberty_latch3
+  verilog_bus_name_newline
 }
 
 define_test_group fast [group_tests all]

--- a/test/verilog_bus_name_newline.ok
+++ b/test/verilog_bus_name_newline.ok
@@ -1,0 +1,17 @@
+module top (in1,
+    in2,
+    out);
+ input in1;
+ input in2;
+ output out;
+
+ wire [1:0] \aaa.aaa ;
+
+ BUFx2_ASAP7_75t_R u1 (.Y(\aaa.aaa [0]),
+    .A(in1));
+ BUFx2_ASAP7_75t_R u2 (.Y(\aaa.aaa [1]),
+    .A(in2));
+ AND2x2_ASAP7_75t_R u3 (.Y(out),
+    .A(\aaa.aaa [0]),
+    .B(\aaa.aaa [1]));
+endmodule

--- a/test/verilog_bus_name_newline.tcl
+++ b/test/verilog_bus_name_newline.tcl
@@ -1,0 +1,4 @@
+read_liberty asap7_small.lib.gz
+read_verilog verilog_bus_name_newline.v
+link_design top
+write_verilog results/verilog_bus_name_newline.log

--- a/test/verilog_bus_name_newline.v
+++ b/test/verilog_bus_name_newline.v
@@ -1,0 +1,10 @@
+module top (in1, in2, out);
+  input in1, in2;
+  output out;
+  wire [1:0] \aaa.aaa ;
+
+  BUFx2_ASAP7_75t_R u1 (.A(in1), .Y(\aaa.aaa [0]));
+  BUFx2_ASAP7_75t_R u2 (.A(in2), .Y(\aaa.aaa [1]));
+  AND2x2_ASAP7_75t_R u3 (.A(\aaa.aaa [0]), .B(\aaa.aaa
+              [1]), .Y(out));
+endmodule


### PR DESCRIPTION
Resolves #146 by stripping newlines from the end of bus names