### PR TITLE
Maintain accuracy on TNS accumulator

### DIFF
--- a/include/sta/Search.hh
+++ b/include/sta/Search.hh
@@ -525,6 +525,7 @@ protected:
 	       PathAPIndex path_ap_index);
   void tnsDecr(Vertex *vertex,
 	       PathAPIndex path_ap_index);
+  void tnsMaintainAccuracy();
   void tnsNotifyBefore(Vertex *vertex);
   bool matchesFilterTo(Path *path,
 		       const ClockEdge *to_clk_edge) const;
@@ -572,6 +573,8 @@ protected:
   // Indexed by path_ap->index().
   SlackSeq tns_;
   // Indexed by path_ap->index().
+  SlackSeq tns_total_delta_;
+  // Indexed by path_ap->index().
   VertexSlackMapSeq tns_slacks_;
   std::mutex tns_lock_;
   // Indexed by path_ap->index().
@@ -618,6 +621,8 @@ protected:
   GatedClk *gated_clk_;
   CheckCrpr *check_crpr_;
   Genclks *genclks_;
+
+  const float tns_resum_threshold_ = 100.0f;
 };
 
 // Eval across latch D->Q edges.


### PR DESCRIPTION
As the TNS total gets incrementally updated it can accumulate a large error. Try to maintain its accuracy by performing a resum if the total of the incremental updates gets to be hundred times larger than the TNS value itself.

On one particular ORFS design, we see the repair starting with a large TNS
```
   Iter   | Removed | Resized | Inserted | Cloned |  Pin  |    WNS   |   TNS      |  Viol  | Worst
          | Buffers |  Gates  | Buffers  |  Gates | Swaps |          |            | Endpts | Endpt
---------------------------------------------------------------------------------------------------
        0 |       0 |       0 |        0 |      0 |     0 | -122.011 | -1370624.1 |  12904 | mem/Gen_dccm_enable_dccm/rd_addr_hi_ff.dffs.dout\[0\]$_DFFE_PN0N_/RN
       10 |       0 |       5 |        0 |      4 |     0 |   -6.189 |   -64746.5 |  12904 | swerv/dec/instbuff.bp1ff.genblock_dff.dout\[43\]$_DFF_PN0_/RN
       20 |       0 |       9 |        0 |     10 |     0 |   -2.342 |   -22922.5 |  12904 | swerv/lsu/dccm_ctl.picm_data_ff.dout\[17\]$_DFF_PN0_/RN
```
At the end of repair, when the TNS is ~4000, there's roughly a 1 % error in the value which goes away with this patch.