### PR TITLE
[liberty] Fix use-before-free bug

### DIFF
--- a/liberty/Liberty.cc
+++ b/liberty/Liberty.cc
@@ -219,7 +219,7 @@ TableTemplate *
 LibertyLibrary::findTableTemplate(const char *name,
 				  TableTemplateType type)
 {
-  return template_maps_[int(type)][name];
+  return template_maps_[int(type)].findKey(name);
 }
 
 TableTemplateSeq


### PR DESCRIPTION
Before this change, findTableTemplate captured `name` always. This caused a segfault when LibertyReader::beginTable calls it with `template_name`:

  const char *template_name = group->firstName();
  if (library_ && template_name) {
    tbl_template_ = library_->findTableTemplate(template_name, type);

This pointer is owned by the group and is freed when we hit sta::libertyGroupEnd.

Ensure that findTableTemplate does not capture `name` by using findKey.