### PR TITLE
Optimize class ExceptionStateSet to improve both runtime and memory usage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ set(STA_SOURCE
   parasitics/SpefReader.cc
   parasitics/SpefReaderPvt.hh
   
+  sdc/SdcClass.cc
   sdc/Clock.cc
   sdc/ClockGatingCheck.cc
   sdc/ClockGroups.cc

--- a/include/sta/Sdc.hh
+++ b/include/sta/Sdc.hh
@@ -993,27 +993,27 @@ public:
 			   const Clock *clk,
 			   const RiseFall *clk_rf,
 			   const MinMax *min_max,
-			   ExceptionStateSet *&states) const;
+			   ExceptionStates &states) const;
   bool exceptionFromStates(const Pin *pin,
 			   const RiseFall *rf,
 			   const Clock *clk,
 			   const RiseFall *clk_rf,
 			   const MinMax *min_max,
 			   bool include_filter,
-			   ExceptionStateSet *&states) const;
+			   ExceptionStates &states) const;
   void exceptionFromClkStates(const Pin *pin,
 			      const RiseFall *rf,
 			      const Clock *clk,
 			      const RiseFall *clk_rf,
 			      const MinMax *min_max,
-			      ExceptionStateSet *&states) const;
+			      ExceptionStates &states) const;
   void filterRegQStates(const Pin *to_pin,
 			const RiseFall *to_rf,
 			const MinMax *min_max,
-			ExceptionStateSet *&states) const;
+			ExceptionStates &states) const;
   // Return hierarchical -thru exceptions that start between
   // from_pin and to_pin.
-  ExceptionStateSet *exceptionThruStates(const Pin *from_pin,
+  ExceptionStates exceptionThruStates(const Pin *from_pin,
                                          const Pin *to_pin,
                                          const RiseFall *to_rf,
                                          const MinMax *min_max) const;
@@ -1176,12 +1176,12 @@ protected:
 			   const RiseFall *rf,
 			   const MinMax *min_max,
 			   bool include_filter,
-			   ExceptionStateSet *&states) const;
+			   ExceptionStates &states) const;
   void exceptionThruStates(const ExceptionPathSet *exceptions,
 			   const RiseFall *to_rf,
 			   const MinMax *min_max,
 			   // Return value.
-			   ExceptionStateSet *&states) const;
+			   ExceptionStates &states) const;
   void exceptionTo(const ExceptionPathSet *to_exceptions,
 		   ExceptionPathType type,
 		   const Pin *pin,

--- a/include/sta/SdcClass.hh
+++ b/include/sta/SdcClass.hh
@@ -116,14 +116,13 @@ class ExceptionPath;
 class ExceptionStates {
 public:
    typedef Set<ExceptionState*, ExceptionStateLess> Super;
-   ExceptionStates(const Network* network) : holder_(nullptr), network_(network), hasLoopPath_(false), hasFilterPath_(false) {}
-   ExceptionStates(ExceptionStates&& o)  noexcept : holder_(o.holder_), network_(o.network_), hasLoopPath_(o.hasLoopPath_), hasFilterPath_(o.hasFilterPath_) {
+   ExceptionStates() : holder_(nullptr), hasLoopPath_(false), hasFilterPath_(false) {}
+   ExceptionStates(ExceptionStates&& o)  noexcept : holder_(o.holder_), hasLoopPath_(o.hasLoopPath_), hasFilterPath_(o.hasFilterPath_) {
     o.holder_ = nullptr;
    }
    ExceptionStates(const ExceptionStates& o) = delete;
    ExceptionStates& operator=(const ExceptionStates & o) = delete;
    ~ExceptionStates() { delete holder_; }
-   const Network* network() const { return network_; }
    explicit operator bool () const { return holder_; }
    bool hasLoopPath() const { return hasLoopPath_; }
    bool hasFilterPath() const { return hasFilterPath_; }
@@ -135,14 +134,12 @@ public:
    void takeOver(ExceptionStates&& o) {
     clear();
     holder_ = o.holder_;
-    network_ = o.network_;
     hasLoopPath_ = o.hasLoopPath_;
     hasFilterPath_ = o.hasFilterPath_;
     o.holder_ = nullptr;
    }
 private:
    Super         *holder_;
-   const Network *network_;
    bool           hasLoopPath_;
    bool           hasFilterPath_;
 };

--- a/include/sta/Search.hh
+++ b/include/sta/Search.hh
@@ -312,8 +312,7 @@ public:
 	       bool is_clk,
 	       InputDelay *input_delay,
 	       bool is_segment_start,
-	       ExceptionStateSet *states,
-	       bool own_states);
+	       const ExceptionStateSet& states);
   void reportTags() const;
   void reportClkInfos() const;
   virtual ClkInfo *findClkInfo(const ClockEdge *clk_edge,

--- a/sdc/Sdc.cc
+++ b/sdc/Sdc.cc
@@ -5126,7 +5126,7 @@ Sdc::exceptionFromStates(const Pin *pin,
 			 const Clock *clk,
 			 const RiseFall *clk_rf,
 			 const MinMax *min_max,
-			 ExceptionStateSet *&states) const
+			 ExceptionStates &states) const
 {
   return exceptionFromStates(pin, rf, clk, clk_rf, min_max, true, states);
 }
@@ -5138,7 +5138,7 @@ Sdc::exceptionFromStates(const Pin *pin,
 			 const RiseFall *clk_rf,
 			 const MinMax *min_max,
 			 bool include_filter,
-			 ExceptionStateSet *&states) const
+			 ExceptionStates &states) const
 {
   bool srch_from = true;
   if (pin) {
@@ -5170,8 +5170,7 @@ Sdc::exceptionFromStates(const Pin *pin,
 				     pin, clk_rf, min_max, include_filter,
 				     states);
   if (!srch_from) {
-    delete states;
-    states = nullptr;
+    states.clear();
   }
   return srch_from;
 }
@@ -5182,7 +5181,7 @@ Sdc::exceptionFromStates(const ExceptionPathSet *exceptions,
 			 const RiseFall *rf,
 			 const MinMax *min_max,
 			 bool include_filter,
-			 ExceptionStateSet *&states) const
+			 ExceptionStates &states) const
 {
   if (exceptions) {
     for (ExceptionPath *exception : *exceptions) {
@@ -5201,17 +5200,13 @@ Sdc::exceptionFromStates(const ExceptionPathSet *exceptions,
 	  // Leave the completed false path state as a marker on the tag,
 	  // but flush all other exception states because they are lower
 	  // priority.
-	  if (states == nullptr)
-	    states = new ExceptionStateSet();
-	  states->clear();
-	  states->insert(state);
+	  states.clear();
+	  states.insert(state);
 	  // No need to examine other exceptions from this
 	  // pin/clock/instance.
 	  return false;
 	}
-	if (states == nullptr)
-	  states = new ExceptionStateSet();
-	states->insert(state);
+  states.insert(state);
       }
     }
   }
@@ -5224,7 +5219,7 @@ Sdc::exceptionFromClkStates(const Pin *pin,
 			    const Clock *clk,
 			    const RiseFall *clk_rf,
 			    const MinMax *min_max,
-			    ExceptionStateSet *&states) const
+			    ExceptionStates &states) const
 {
   if (pin) {
     if (!first_from_pin_exceptions_.empty())
@@ -5247,7 +5242,7 @@ void
 Sdc::filterRegQStates(const Pin *to_pin,
 		      const RiseFall *to_rf,
 		      const MinMax *min_max,
-		      ExceptionStateSet *&states) const
+		      ExceptionStates &states) const
 {
   if (!first_from_pin_exceptions_.empty()) {
     const ExceptionPathSet *exceptions =
@@ -5258,22 +5253,20 @@ Sdc::filterRegQStates(const Pin *to_pin,
 	if (exception->isFilter()
 	    && exception->matchesFirstPt(to_rf, min_max)) {
 	  ExceptionState *state = exception->firstState();
-	  if (states == nullptr)
-	    states = new ExceptionStateSet();
-	  states->insert(state);
+	  states.insert(state);
 	}
       }
     }
   }
 }
 
-ExceptionStateSet *
+ExceptionStates
 Sdc::exceptionThruStates(const Pin *from_pin,
 			 const Pin *to_pin,
 			 const RiseFall *to_rf,
 			 const MinMax *min_max) const
 {
-  ExceptionStateSet *states = nullptr;
+  ExceptionStates states(network_);
   exceptionThruStates(first_thru_pin_exceptions_.findKey(to_pin),
                       to_rf, min_max, states);
   if (!first_thru_edge_exceptions_.empty()) {
@@ -5296,15 +5289,13 @@ Sdc::exceptionThruStates(const ExceptionPathSet *exceptions,
 			 const RiseFall *to_rf,
 			 const MinMax *min_max,
 			 // Return value.
-			 ExceptionStateSet *&states) const
+			 ExceptionStates &states) const
 {
   if (exceptions) {
     for (ExceptionPath *exception : *exceptions) {
       if (exception->matchesFirstPt(to_rf, min_max)) {
 	ExceptionState *state = exception->firstState();
-	if (states == nullptr)
-	  states = new ExceptionStateSet();
-	states->insert(state);
+	states.insert(state);
       }
     }
   }

--- a/sdc/Sdc.cc
+++ b/sdc/Sdc.cc
@@ -5266,7 +5266,7 @@ Sdc::exceptionThruStates(const Pin *from_pin,
 			 const RiseFall *to_rf,
 			 const MinMax *min_max) const
 {
-  ExceptionStates states(network_);
+  ExceptionStates states;
   exceptionThruStates(first_thru_pin_exceptions_.findKey(to_pin),
                       to_rf, min_max, states);
   if (!first_thru_edge_exceptions_.empty()) {

--- a/sdc/SdcClass.cc
+++ b/sdc/SdcClass.cc
@@ -1,0 +1,76 @@
+#include "SdcClass.hh"
+#include "Sdc.hh"
+
+namespace sta {
+
+void
+ExceptionStates::insert(ExceptionState* state) {
+  if (!holder_) holder_ = new Super;
+  holder_->insert(state);
+  if (!hasLoopPath_ && state->exception()->isLoop())     hasLoopPath_ = true;
+  if (!hasFilterPath_ && state->exception()->isFilter()) hasFilterPath_ = true;
+}
+
+void
+ExceptionStates::clear() {
+  delete holder_;
+  holder_ = nullptr;
+  hasLoopPath_ = false;
+}
+
+bool
+ExceptionStateSet::Impl::operator == (Impl const & i) const {
+  return (*(Super*)this) == (*(Super*)&i);
+}
+
+void
+ExceptionStateSet::Impl::rehash() {
+  hash_ = hash_init_value;
+  for(auto* state : *this) {
+    hashIncr(hash_, state->hash());
+  }
+}
+
+bool
+ExceptionStateSet::operator==(const ExceptionStateSet& o) const {
+  return impl == o.impl;
+}
+
+thread_local ExceptionStateSet::Manager
+ExceptionStateSet::mgr;
+
+ExceptionStateSet::Impl*
+ExceptionStateSet::unique(Impl* i) {
+  if (i->empty()) {
+    delete i;
+    return nullptr;
+  }
+  auto r = mgr.insert(i);
+  if (!r.second) {
+	delete i;
+	i = *r.first;
+  }
+  return i;
+}
+
+ExceptionStateSet::Impl*
+ExceptionStateSet::create(ExceptionStates & tmp) {
+  return tmp ? unique(new Impl(tmp)) : nullptr;
+}
+
+int
+ExceptionStateSet::cmp (const ExceptionStateSet & o) const {
+  size_t sz1 = size();
+  size_t sz2 = o.size();
+  if (sz1 != sz2) return sz1 < sz2 ? 1 : -1;
+  if (!sz1) return true;
+  auto it1 = begin();
+  auto it2 = o.begin();
+  while (*it1 == *it2) {
+    ++it1, ++it2;
+  }
+  if (it1 == end()) return 0;
+  return *it1 < *it2 ? 1 : -1;
+}
+
+} // end namespace sta

--- a/search/CheckMinPulseWidths.cc
+++ b/search/CheckMinPulseWidths.cc
@@ -337,7 +337,7 @@ MinPulseWidthCheck::closePath(const StaState *sta,
 		open_tag->inputDelay(),
 		open_tag->isSegmentStart(),
 		open_tag->states(),
-		false, sta);
+		sta);
   debugPrint(sta->debug(), "mpw", 3, " open  %s",
              open_tag->asString(sta));
   debugPrint(sta->debug(), "mpw", 3, " close %s",

--- a/search/Genclks.cc
+++ b/search/Genclks.cc
@@ -703,7 +703,7 @@ Genclks::makeTag(const Clock *gclk,
   // from the get go.
   if (master_pin == gclk->srcPin())
     state = state->nextState();
-  ExceptionStates states(network_);
+  ExceptionStates states;
   states.insert(state);
   ClkInfo *clk_info = search_->findClkInfo(master_clk->edge(master_rf),
 					   master_pin, true, nullptr, true,

--- a/search/Latches.cc
+++ b/search/Latches.cc
@@ -364,7 +364,7 @@ Latches::latchOutArrival(Path *data_path,
 				    path_ap,
 				    crpr_clk_path);
 	     RiseFall *q_rf = d_q_arc->toEdge()->asRiseFall();
-	     ExceptionStateSet *states = nullptr;
+	     ExceptionStates states(network_);
 	     // Latch data pin is a valid exception -from pin.
 	     if (sdc_->exceptionFromStates(data_path->pin(this),
 						   data_path->transition(this),
@@ -377,7 +377,7 @@ Latches::latchOutArrival(Path *data_path,
 						      en_clk_edge->transition(),
 						      MinMax::max(), false, states))
 	       q_tag = search_->findTag(q_rf, path_ap, q_clk_info, false,
-					nullptr, false, states, true);
+					nullptr, false, states);
 	   }
 	   return;
 	 }

--- a/search/Latches.cc
+++ b/search/Latches.cc
@@ -364,7 +364,7 @@ Latches::latchOutArrival(Path *data_path,
 				    path_ap,
 				    crpr_clk_path);
 	     RiseFall *q_rf = d_q_arc->toEdge()->asRiseFall();
-	     ExceptionStates states(network_);
+	     ExceptionStates states;
 	     // Latch data pin is a valid exception -from pin.
 	     if (sdc_->exceptionFromStates(data_path->pin(this),
 						   data_path->transition(this),

--- a/search/PathEnum.cc
+++ b/search/PathEnum.cc
@@ -609,7 +609,7 @@ PathEnum::updatePathHeadDelays(PathEnumedSeq &paths,
                                             tag->isClock(),
                                             tag->inputDelay(),
                                             tag->isSegmentStart(),
-                                            tag->states(), false);
+                                            tag->states());
         path->setTag(updated_tag);
       }
     }

--- a/search/PathVertex.cc
+++ b/search/PathVertex.cc
@@ -420,16 +420,14 @@ PrevPathVisitor::visitFromToPath(const Pin *,
 Tag *
 PrevPathVisitor::unfilteredTag(const Tag *tag) const
 {
-  ExceptionStateSet *unfiltered_states = nullptr;
-  const ExceptionStateSet *states = tag->states();
-  ExceptionStateSet::ConstIterator state_iter(states);
-  while (state_iter.hasNext()) {
-    ExceptionState *state = state_iter.next();
+  const ExceptionStateSet& states = tag->states();
+  if (!states.hasFilterPath())
+    return (Tag*)tag;
+  ExceptionStates unfiltered_states(network_);
+  for (ExceptionState *state : states) {
     ExceptionPath *except = state->exception();
     if (!except->isFilter()) {
-      if (unfiltered_states == nullptr)
-	unfiltered_states = new ExceptionStateSet();
-      unfiltered_states->insert(state);
+      unfiltered_states.insert(state);
     }
   }
   return search_->findTag(tag->transition(),
@@ -438,7 +436,7 @@ PrevPathVisitor::unfilteredTag(const Tag *tag) const
                           tag->isClock(),
                           tag->inputDelay(),
                           tag->isSegmentStart(),
-                          unfiltered_states, true);
+                          unfiltered_states);
 }
 
 ////////////////////////////////////////////////////////////////

--- a/search/PathVertex.cc
+++ b/search/PathVertex.cc
@@ -423,7 +423,7 @@ PrevPathVisitor::unfilteredTag(const Tag *tag) const
   const ExceptionStateSet& states = tag->states();
   if (!states.hasFilterPath())
     return (Tag*)tag;
-  ExceptionStates unfiltered_states(network_);
+  ExceptionStates unfiltered_states;
   for (ExceptionState *state : states) {
     ExceptionPath *except = state->exception();
     if (!except->isFilter()) {

--- a/search/Search.cc
+++ b/search/Search.cc
@@ -1561,7 +1561,7 @@ Search::seedClkArrival(const Pin *pin,
 				  pulse_clk_sense, insertion, latency,
 				  uncertainties, path_ap, nullptr);
   // Only false_paths -from apply to clock tree pins.
-  ExceptionStates states(network_);
+  ExceptionStates states;
   sdc_->exceptionFromClkStates(pin,rf,clk,rf,min_max,states);
   Tag *tag = findTag(rf, path_ap, clk_info, true, nullptr, false, states);
   Arrival arrival(clk_edge->time() + insertion);
@@ -1595,7 +1595,7 @@ Search::clkDataTag(const Pin *pin,
  		   const MinMax *min_max,
  		   const PathAnalysisPt *path_ap)
 {
-  ExceptionStates states(network_);
+  ExceptionStates states;
   if (sdc_->exceptionFromStates(pin, rf, clk, rf, min_max, states)) {
     bool is_propagated = (clk->isPropagated()
 			  || sdc_->isPropagatedClock(pin));
@@ -1954,7 +1954,7 @@ Search::inputDelayTag(const Pin *pin,
     clk_uncertainties = clk->uncertainties();
   }
 
-  ExceptionStates states(network_);
+  ExceptionStates states;
   Tag *tag = nullptr;
   if (sdc_->exceptionFromStates(pin,rf,clk,clk_rf,min_max,states)) {
     ClkInfo *clk_info = findClkInfo(clk_edge, clk_pin, is_propagated, nullptr,
@@ -2321,7 +2321,7 @@ Search::fromUnclkedInputTag(const Pin *pin,
 			    bool is_segment_start,
                             bool require_exception)
 {
-  ExceptionStates states(network_);
+  ExceptionStates states;
   if (sdc_->exceptionFromStates(pin, rf, nullptr, nullptr, min_max, states)
       && (!require_exception || states)) {
     ClkInfo *clk_info = findClkInfo(nullptr, nullptr, false, 0.0, path_ap);
@@ -2342,7 +2342,7 @@ Search::fromRegClkTag(const Pin *from_pin,
 		      const MinMax *min_max,
 		      const PathAnalysisPt *path_ap)
 {
-  ExceptionStates states(network_);
+  ExceptionStates states;
   if (sdc_->exceptionFromStates(from_pin, from_rf, clk, clk_rf,
 				min_max, states)) {
     // Hack for filter -from reg/Q.
@@ -2541,7 +2541,7 @@ Search::mutateTag(Tag *from_tag,
 		  const MinMax *min_max,
 		  const PathAnalysisPt *path_ap)
 {
-  ExceptionStates new_states(network_);
+  ExceptionStates new_states;
   ExceptionStateSet from_states = from_tag->states();
   if (from_states) {
     // Check for state changes in from_tag (but postpone copying state set).

--- a/search/Search.cc
+++ b/search/Search.cc
@@ -1561,9 +1561,9 @@ Search::seedClkArrival(const Pin *pin,
 				  pulse_clk_sense, insertion, latency,
 				  uncertainties, path_ap, nullptr);
   // Only false_paths -from apply to clock tree pins.
-  ExceptionStateSet *states = nullptr;
+  ExceptionStates states(network_);
   sdc_->exceptionFromClkStates(pin,rf,clk,rf,min_max,states);
-  Tag *tag = findTag(rf, path_ap, clk_info, true, nullptr, false, states, true);
+  Tag *tag = findTag(rf, path_ap, clk_info, true, nullptr, false, states);
   Arrival arrival(clk_edge->time() + insertion);
   tag_bldr->setArrival(tag, arrival, nullptr);
 }
@@ -1595,13 +1595,13 @@ Search::clkDataTag(const Pin *pin,
  		   const MinMax *min_max,
  		   const PathAnalysisPt *path_ap)
 {
-  ExceptionStateSet *states = nullptr;
+  ExceptionStates states(network_);
   if (sdc_->exceptionFromStates(pin, rf, clk, rf, min_max, states)) {
     bool is_propagated = (clk->isPropagated()
 			  || sdc_->isPropagatedClock(pin));
     ClkInfo *clk_info = findClkInfo(clk_edge, pin, is_propagated,
 				    insertion, path_ap);
-    return findTag(rf, path_ap, clk_info, false, nullptr, false, states, true);
+    return findTag(rf, path_ap, clk_info, false, nullptr, false, states);
   }
   else
     return nullptr;
@@ -1954,14 +1954,14 @@ Search::inputDelayTag(const Pin *pin,
     clk_uncertainties = clk->uncertainties();
   }
 
-  ExceptionStateSet *states = nullptr;
+  ExceptionStates states(network_);
   Tag *tag = nullptr;
   if (sdc_->exceptionFromStates(pin,rf,clk,clk_rf,min_max,states)) {
     ClkInfo *clk_info = findClkInfo(clk_edge, clk_pin, is_propagated, nullptr,
 				    false, nullptr, clk_insertion, clk_latency,
 				    clk_uncertainties, path_ap, nullptr);
     tag = findTag(rf, path_ap, clk_info, false, input_delay, is_segment_start,
-		  states, true);
+		  states);
   }
 
   if (tag) {
@@ -2321,12 +2321,12 @@ Search::fromUnclkedInputTag(const Pin *pin,
 			    bool is_segment_start,
                             bool require_exception)
 {
-  ExceptionStateSet *states = nullptr;
+  ExceptionStates states(network_);
   if (sdc_->exceptionFromStates(pin, rf, nullptr, nullptr, min_max, states)
       && (!require_exception || states)) {
     ClkInfo *clk_info = findClkInfo(nullptr, nullptr, false, 0.0, path_ap);
     return findTag(rf, path_ap, clk_info, false, nullptr,
-                   is_segment_start, states, true);
+                   is_segment_start, states);
   }
   return nullptr;
 }
@@ -2342,12 +2342,12 @@ Search::fromRegClkTag(const Pin *from_pin,
 		      const MinMax *min_max,
 		      const PathAnalysisPt *path_ap)
 {
-  ExceptionStateSet *states = nullptr;
+  ExceptionStates states(network_);
   if (sdc_->exceptionFromStates(from_pin, from_rf, clk, clk_rf,
 				min_max, states)) {
     // Hack for filter -from reg/Q.
     sdc_->filterRegQStates(to_pin, to_rf, min_max, states);
-    return findTag(to_rf, path_ap, clk_info, false, nullptr, false, states, true);
+    return findTag(to_rf, path_ap, clk_info, false, nullptr, false, states);
   }
   else
     return nullptr;
@@ -2541,12 +2541,12 @@ Search::mutateTag(Tag *from_tag,
 		  const MinMax *min_max,
 		  const PathAnalysisPt *path_ap)
 {
-  ExceptionStateSet *new_states = nullptr;
-  ExceptionStateSet *from_states = from_tag->states();
+  ExceptionStates new_states(network_);
+  ExceptionStateSet from_states = from_tag->states();
   if (from_states) {
     // Check for state changes in from_tag (but postpone copying state set).
     bool state_change = false;
-    for (auto state : *from_states) {
+    for (auto state : from_states) {
       ExceptionPath *exception = state->exception();
       // One edge may traverse multiple hierarchical thru pins.
       while (state->matchesNextThru(from_pin,to_pin,to_rf,min_max,network_)) {
@@ -2581,13 +2581,11 @@ Search::mutateTag(Tag *from_tag,
     }
 
     // Get the set of -thru exceptions starting at to_pin/edge.
-    new_states = sdc_->exceptionThruStates(from_pin, to_pin, to_rf, min_max);
+    new_states.takeOver(sdc_->exceptionThruStates(from_pin, to_pin, to_rf, min_max));
     if (new_states || state_change) {
       // Second pass to apply state changes and add updated existing
       // states to new states.
-      if (new_states == nullptr)
-	new_states = new ExceptionStateSet();
-      for (auto state : *from_states) {
+      for (auto state : from_states) {
 	ExceptionPath *exception = state->exception();
 	// One edge may traverse multiple hierarchical thru pins.
 	while (state->matchesNextThru(from_pin,to_pin,to_rf,min_max,network_))
@@ -2603,7 +2601,6 @@ Search::mutateTag(Tag *from_tag,
           // to_pin/edge completes a loop path.
           || (exception->isLoop()
               && state->isComplete())) {
-        delete new_states;
 	return nullptr;
       }
 
@@ -2613,18 +2610,18 @@ Search::mutateTag(Tag *from_tag,
               // Kill loop tags at register clock pins.
               || (to_is_reg_clk
                   && exception->isLoop())))
-	  new_states->insert(state);
+	  new_states.insert(state);
       }
     }
   }
   else
     // Get the set of -thru exceptions starting at to_pin/edge.
-    new_states = sdc_->exceptionThruStates(from_pin, to_pin, to_rf, min_max);
+    new_states.takeOver(sdc_->exceptionThruStates(from_pin, to_pin, to_rf, min_max));
 
   if (new_states)
     return findTag(to_rf, path_ap, to_clk_info, to_is_clk,
 		   from_tag->inputDelay(), to_is_segment_start,
-		   new_states, true);
+		   new_states);
   else {
     // No state change.
     if (to_clk_info == from_clk_info
@@ -2636,7 +2633,7 @@ Search::mutateTag(Tag *from_tag,
     else
       return findTag(to_rf, path_ap, to_clk_info, to_is_clk,
 		     to_input_delay, to_is_segment_start,
-		     from_states, false);
+		     from_states);
   }
 }
 
@@ -2873,16 +2870,13 @@ Search::findTag(const RiseFall *rf,
 		bool is_clk,
 		InputDelay *input_delay,
 		bool is_segment_start,
-		ExceptionStateSet *states,
-		bool own_states)
+		const ExceptionStateSet& states)
 {
   Tag probe(0, rf->index(), path_ap->index(), clk_info, is_clk, input_delay,
-	    is_segment_start, states, false, this);
+	    is_segment_start, states, this);
   LockGuard lock(tag_lock_);
   Tag *tag = tag_set_->findKey(&probe);
   if (tag == nullptr) {
-    ExceptionStateSet *new_states = !own_states && states
-      ? new ExceptionStateSet(*states) : states;
     TagIndex tag_index;
     if (tag_free_indices_.empty())
       tag_index = tag_next_++;
@@ -2892,8 +2886,7 @@ Search::findTag(const RiseFall *rf,
     }
     tag = new Tag(tag_index, rf->index(), path_ap->index(),
                   clk_info, is_clk, input_delay, is_segment_start,
-                  new_states, true, this);
-    own_states = false;
+                  states, this);
     // Make sure tag can be indexed in tags_ before it is visible to
     // other threads via tag_set_.
     tags_[tag_index] = tag;
@@ -2916,8 +2909,6 @@ Search::findTag(const RiseFall *rf,
     if (tag_next_ == tag_index_max)
       report_->critical(1511, "max tag index exceeded");
   }
-  if (own_states)
-    delete states;
   return tag;
 }
 
@@ -3613,9 +3604,9 @@ Search::matchesFilter(Path *path,
     // -from pins|inst
     // -thru
     // Path has to be tagged by traversing the filter exception points.
-    ExceptionStateSet *states = path->tag(this)->states();
+    const ExceptionStateSet& states = path->tag(this)->states();
     if (states) {
-      for (auto state : *states) {
+      for (auto state : states) {
 	if (state->exception() == filter_
 	    && state->nextThru() == nullptr
 	    && matchesFilterTo(path, to_clk_edge))
@@ -3674,9 +3665,9 @@ Search::exceptionTo(ExceptionPathType type,
   // Find the highest priority exception carried by the path's tag.
   int hi_priority = -1;
   ExceptionPath *hi_priority_exception = nullptr;
-  const ExceptionStateSet *states = path->tag(this)->states();
+  const ExceptionStateSet& states = path->tag(this)->states();
   if (states) {
-    for (auto state : *states) {
+    for (auto state : states) {
       ExceptionPath *exception = state->exception();
       int priority = exception->priority(min_max);
       if ((type == ExceptionPathType::any

--- a/search/Tag.hh
+++ b/search/Tag.hh
@@ -50,8 +50,7 @@ public:
       bool is_clk,
       InputDelay *input_delay,
       bool is_segment_start,
-      ExceptionStateSet *states,
-      bool own_states,
+      const ExceptionStateSet& states,
       const StaState *sta);
   ~Tag();
   const char *asString(const StaState *sta) const;
@@ -68,8 +67,8 @@ public:
   PathAnalysisPt *pathAnalysisPt(const StaState *sta) const;
   PathAPIndex pathAPIndex() const { return path_ap_index_; }
   TagIndex index() const { return index_; }
-  ExceptionStateSet *states() const { return states_; }
-  void setStates(ExceptionStateSet *states);
+  const ExceptionStateSet& states() const { return states_; }
+  void setStates(const ExceptionStateSet& states);
   bool isGenClkSrcPath() const;
   const Clock *genClkSrcPathClk(const StaState *sta) const;
   // Input delay at search startpoint (not propagated).
@@ -86,7 +85,7 @@ protected:
 private:
   ClkInfo *clk_info_;
   InputDelay *input_delay_;
-  ExceptionStateSet *states_;
+  ExceptionStateSet states_;
   size_t hash_;
   size_t match_hash_;
   TagIndex index_;


### PR DESCRIPTION
---
motivation && reason
---
Under the original ExceptionStateSet architecture, we observed that during the process of exception propagation, **the STA would attempt to create an ExceptionStateSet for each specific Vertex and Tag**, even if it was entirely unrelated to that point and could have been completely copied from the ExceptionStateSet of the previous stage. Like following:
```
if (states == nullptr)
  states = new ExceptionStateSet();
states->insert(state);
```

This meant that a large number of identical ExceptionStateSet instances were created, even though their contents were exactly the same, leading to **unnecessary memory overhead**. 

Furthermore, under this architecture, every time a Tag Match was performed, the STA needed to repeatedly compare the elements within the ExceptionStateSet. Additionally, when calculating the Tag Hash, it had to repeatedly iterate over and compute the hash values of each Exception in the ExceptionStateSet. This resulted in **significant additional runtime overhead**.

---
action && improvement
---
We refactored the ExceptionStateSet structure and observed over a 5% runtime improvement through testing with the pprof tool on our test design, along with minor memory optimizations. The changes we made include the following:

1. Ensured that ExceptionStateSet instances with identical contents are treated as the same element.
2. With the above adjustment, Tag Match/Exception Match operations can now match pointers instead of comparing their actual contents.
3. Cached the hash of the ExceptionStateSet, eliminating the need to recalculate it every time a Tag is created.
4. Replaced the use of OwnState for memory management with a reference counting (refCount) approach.

---
pprof data && evidence
---

> Under design with about 150k instances, 4 corners, dozens of exceptions && clocks.
> Read design and find requireds.

- Before this pull request:
[before_this_pr.pdf](https://github.com/user-attachments/files/18393820/before_this_pr.pdf)

- After this pull request:
[after_this_pr.pdf](https://github.com/user-attachments/files/18393825/after_this_pr.pdf)
_**You can see the sample time percentage of function "findTag" improved from 12.3% to 5.9%.**_
---