### PR TITLE
Verilog reader enhancement to support swapping to uninstantiated modules

### DIFF
--- a/include/sta/ConcreteNetwork.hh
+++ b/include/sta/ConcreteNetwork.hh
@@ -59,7 +59,8 @@ public:
   void clear() override;
   bool linkNetwork(const char *top_cell_name,
                    bool make_black_boxes,
-                   Report *report) override;
+                   Report *report,
+                   bool use_top_cell_name = false) override;
   Instance *topInstance() const override;
 
   const char *name(const Library *library) const override;

--- a/include/sta/Network.hh
+++ b/include/sta/Network.hh
@@ -37,6 +37,7 @@ typedef Map<const char*, LibertyLibrary*, CharPtrLess> LibertyLibraryMap;
 typedef Instance *(LinkNetworkFunc)(const char *top_cell_name,
 				    bool make_black_boxes,
 				    Report *report,
+                                    bool use_top_cell_name,
 				    NetworkReader *network);
 typedef Map<const Net*, PinSet*> NetDrvrPinsMap;
 
@@ -96,7 +97,8 @@ public:
   // Return true if successful.
   virtual bool linkNetwork(const char *top_cell_name,
 			   bool make_black_boxes,
-			   Report *report) = 0;
+			   Report *report,
+                           bool use_top_cell_name = false) = 0;
   virtual bool isLinked() const;
   virtual bool isEditable() const { return false; }
 

--- a/include/sta/SdcNetwork.hh
+++ b/include/sta/SdcNetwork.hh
@@ -30,7 +30,8 @@ public:
   NetworkNameAdapter(Network *network);
   bool linkNetwork(const char *top_cell_name,
                    bool make_black_boxes,
-                   Report *report) override;
+                   Report *report,
+                   bool use_top_cell_name = false) override;
 
   const char *name(const Library *library) const override;
   ObjectId id(const Library *library) const override;

--- a/network/ConcreteNetwork.cc
+++ b/network/ConcreteNetwork.cc
@@ -1959,12 +1959,14 @@ ConcreteNetwork::setLinkFunc(LinkNetworkFunc *link)
 bool
 ConcreteNetwork::linkNetwork(const char *top_cell_name,
 			     bool make_black_boxes,
-			     Report *report)
+			     Report *report,
+                             bool use_top_cell_name)
 {
   if (link_func_) {
     clearConstantNets();
     deleteTopInstance();
-    top_instance_ = link_func_(top_cell_name, make_black_boxes, report, this);
+    top_instance_ = link_func_(top_cell_name, make_black_boxes, report,
+                               use_top_cell_name, this);
     if (top_instance_)
       checkNetworkLibertyCorners();
     return top_instance_ != nullptr;

--- a/network/SdcNetwork.cc
+++ b/network/SdcNetwork.cc
@@ -41,9 +41,11 @@ NetworkNameAdapter::NetworkNameAdapter(Network *network) :
 bool
 NetworkNameAdapter::linkNetwork(const char *top_cell_name,
 				bool make_black_boxes,
-				Report *report)
+				Report *report,
+                                bool use_top_cell_name)
 {
-  return network_->linkNetwork(top_cell_name, make_black_boxes, report);
+  return network_->linkNetwork(top_cell_name, make_black_boxes, report,
+                               use_top_cell_name);
 }
 
 Instance *

--- a/verilog/VerilogReaderPvt.hh
+++ b/verilog/VerilogReaderPvt.hh
@@ -157,7 +157,8 @@ public:
   VerilogModule *module(Cell *cell);
   Instance *linkNetwork(const char *top_cell_name,
 			bool make_black_boxes,
-			Report *report);
+			Report *report,
+                        bool use_top_cell_name = false);
   int line() const { return line_; }
   const char *filename() const { return filename_.c_str(); }
   void incrLine();


### PR DESCRIPTION
1) mark black box cells during linking to exclude them from swapping candidates
2) defer module deletion to VerilogReader destructor
3) use actual module name name when linking unused modules as top cell