### PR TITLE
Add const getters to PowerResult

### DIFF
--- a/include/sta/PowerClass.hh
+++ b/include/sta/PowerClass.hh
@@ -70,8 +70,11 @@ public:
   PowerResult();
   void clear();
   float &internal() { return internal_; }
+  float internal() const { return internal_; }
   float &switching() { return switching_; }
+  float switching() const { return switching_; }
   float &leakage() { return leakage_; }
+  float leakage() const { return leakage_; }
   float total() const;
   void incr(PowerResult &result);
   


### PR DESCRIPTION
Allows accessing the results in a const object.