### PR TITLE
Report json fixes

### DIFF
--- a/search/ReportPath.cc
+++ b/search/ReportPath.cc
@@ -335,7 +335,7 @@ void
 ReportPath::reportPathEnds(PathEndSeq *ends)
 {
   reportPathEndHeader();
-  if (ends && ends->size()) {
+  if (ends && !ends->empty()) {
     PathEndSeq::Iterator end_iter(ends);
     PathEnd *prev_end = nullptr;
     while (end_iter.hasNext()) {

--- a/search/ReportPath.cc
+++ b/search/ReportPath.cc
@@ -335,7 +335,7 @@ void
 ReportPath::reportPathEnds(PathEndSeq *ends)
 {
   reportPathEndHeader();
-  if (ends) {
+  if (ends && ends->size()) {
     PathEndSeq::Iterator end_iter(ends);
     PathEnd *prev_end = nullptr;
     while (end_iter.hasNext()) {
@@ -343,6 +343,10 @@ ReportPath::reportPathEnds(PathEndSeq *ends)
       reportPathEnd(end, prev_end, !end_iter.hasNext());
       prev_end = end;
     }
+  }
+  else {
+    if (format_ != ReportPathFormat::json)
+      report_->reportLine("No paths found.");
   }
   reportPathEndFooter();
 }

--- a/search/Search.i
+++ b/search/Search.i
@@ -512,13 +512,7 @@ report_path_cmd(PathRef *path)
 void
 report_path_ends(PathEndSeq *ends)
 {
-  Sta *sta = Sta::sta();
-  Report *report = sta->report();
-  ReportPathFormat path_format = sta->reportPath()->pathFormat();
-  if (path_format == ReportPathFormat::json || (ends && ends->size() > 0))
-    sta->reportPathEnds(ends);
-  else
-    report->reportLine("No paths found.");
+  Sta::sta()->reportPathEnds(ends);
 }
 
 ////////////////////////////////////////////////////////////////

--- a/search/Search.i
+++ b/search/Search.i
@@ -513,6 +513,7 @@ void
 report_path_ends(PathEndSeq *ends)
 {
   Sta::sta()->reportPathEnds(ends);
+  delete ends;
 }
 
 ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Move "No paths found." logic to `ReportPath::reportPathEnds` where it belongs
- Delete `ends` to fix memory leak