### PR TITLE
DO NOT MERGE testing faster map for vcd reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ doc/._Sta.docx
 test/results
 # ngspice turd
 test/b3v3_1check.log
+*.a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,6 +516,7 @@ target_sources(OpenSTA
 )
 
 target_link_libraries(OpenSTA
+  PUBLIC
   Eigen3::Eigen
   ${TCL_LIBRARY}
   ${CMAKE_THREAD_LIBS_INIT}
@@ -523,7 +524,7 @@ target_link_libraries(OpenSTA
   )
 
 if (ZLIB_LIBRARIES)
-  target_link_libraries(OpenSTA ${ZLIB_LIBRARIES})
+  target_link_libraries(OpenSTA PRIVATE ${ZLIB_LIBRARIES})
 endif()
 
 target_include_directories(OpenSTA
@@ -541,7 +542,7 @@ target_include_directories(OpenSTA
   )
 
 if (TCL_READLINE)
-  target_link_libraries(OpenSTA ${TCL_READLINE_LIBRARY})
+  target_link_libraries(OpenSTA PRIVATE ${TCL_READLINE_LIBRARY})
   target_include_directories(OpenSTA
     PUBLIC
     ${TCL_READLINE_INCLUDE})
@@ -580,6 +581,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${STA_HOME}/app)
 add_executable(sta app/Main.cc)
 
 target_link_libraries(sta
+  PRIVATE
   sta_swig
   OpenSTA
   )
@@ -610,3 +612,9 @@ add_custom_target(sta_tags etags -o TAGS
   ${SWIG_TCL_FILES}
   WORKING_DIRECTORY ${STA_HOME}
   )
+
+find_package(absl REQUIRED)
+
+# Link Abseil to your targets
+target_link_libraries(sta PRIVATE absl::flat_hash_map)
+target_link_libraries(OpenSTA PRIVATE absl::flat_hash_map)

--- a/power/VcdParse.cc
+++ b/power/VcdParse.cc
@@ -204,6 +204,9 @@ VcdParse::parseVarValues()
 {
   string token = getToken();
   while (!token.empty()) {
+    if ((value_count++ % 10000000) == 0) {
+      report_->reportLine("Read %zu values.", value_count);
+    }
     char char0 = toupper(token[0]);
     if (char0 == '#' && token.size() > 1) {
       prev_time_ = time_;

--- a/power/VcdParse.hh
+++ b/power/VcdParse.hh
@@ -81,6 +81,8 @@ private:
   string readStmtString();
   vector<string> readStmtTokens();
 
+  size_t value_count = 0;
+
   VcdReader *reader_;
   gzFile stream_;
   string token_;

--- a/power/VcdReader.cc
+++ b/power/VcdReader.cc
@@ -27,6 +27,7 @@
 #include <inttypes.h>
 #include <set>
 #include "absl/container/flat_hash_map.h"
+#include <boost/unordered_map.hpp>
 
 #include "VcdParse.hh"
 #include "Debug.hh"
@@ -117,8 +118,9 @@ VcdCount::highTime(VcdTime time_max) const
 // VcdCount[bit]
 typedef vector<VcdCount> VcdCounts;
 // ID -> VcdCount[bit]
-typedef absl::flat_hash_map<string, VcdCounts> VcdIdCountsMap;
+//typedef absl::flat_hash_map<string, VcdCounts> VcdIdCountsMap;
 //typedef map<string, VcdCounts> VcdIdCountsMap;
+typedef boost::unordered_map<string, VcdCounts> VcdIdCountsMap;
 
 class VcdCountReader : public VcdReader
 {

--- a/power/VcdReader.cc
+++ b/power/VcdReader.cc
@@ -26,8 +26,10 @@
 
 #include <inttypes.h>
 #include <set>
-#include "absl/container/flat_hash_map.h"
-#include <boost/unordered_map.hpp>
+// #include "absl/container/flat_hash_map.h"
+// #include <boost/unordered_map.hpp>
+#include <boost/unordered/unordered_flat_map.hpp>
+
 
 #include "VcdParse.hh"
 #include "Debug.hh"
@@ -120,7 +122,7 @@ typedef vector<VcdCount> VcdCounts;
 // ID -> VcdCount[bit]
 //typedef absl::flat_hash_map<string, VcdCounts> VcdIdCountsMap;
 //typedef map<string, VcdCounts> VcdIdCountsMap;
-typedef boost::unordered_map<string, VcdCounts> VcdIdCountsMap;
+typedef boost::unordered_flat_map<string, VcdCounts> VcdIdCountsMap;
 
 class VcdCountReader : public VcdReader
 {

--- a/power/VcdReader.cc
+++ b/power/VcdReader.cc
@@ -27,12 +27,6 @@
 #include <inttypes.h>
 #include <set>
 #include "absl/container/flat_hash_map.h"
-#include <boost/multi_index_container.hpp>
-#include <boost/multi_index/hashed_index.hpp>
-#include <boost/multi_index/ordered_index.hpp>
-#include <boost/multi_index/member.hpp>
-#include <boost/unordered_map.hpp>
-
 
 #include "VcdParse.hh"
 #include "Debug.hh"
@@ -123,38 +117,8 @@ VcdCount::highTime(VcdTime time_max) const
 // VcdCount[bit]
 typedef vector<VcdCount> VcdCounts;
 // ID -> VcdCount[bit]
-//typedef absl::flat_hash_map<string, VcdCounts> VcdIdCountsMap;
+typedef absl::flat_hash_map<string, VcdCounts> VcdIdCountsMap;
 //typedef map<string, VcdCounts> VcdIdCountsMap;
-typedef boost::unordered_map<std::string, VcdCounts> VcdIdCountsMap;
-
-
-struct CacheEntry {
-  std::string key;
-  VcdCounts* value;
-};
-
-struct KeyExtractor {
-  typedef std::string result_type;
-  const std::string& operator()(const CacheEntry& entry) const {
-    return entry.key;
-  }
-};
-
-using namespace boost::multi_index;
-
-typedef multi_index_container<
-  CacheEntry,
-  indexed_by<
-    hashed_unique<
-      KeyExtractor
-    >,
-    ordered_non_unique<
-      member<CacheEntry, std::string, &CacheEntry::key>
-    >
-  >
-> LRUCache;
-
-
 
 class VcdCountReader : public VcdReader
 {
@@ -195,36 +159,6 @@ private:
                  size_t width,
                  size_t bit_idx);
 
-
-void evict_if_needed() {
-  if (cache_.size() > cache_capacity_) {
-    auto& ordered_index = cache_.get<1>();
-    ordered_index.erase(ordered_index.begin());
-  }
-}
-
-VcdCounts* find(const std::string& id) {
-  // Check the cache first
-  auto& hashed_index = cache_.get<0>();
-  auto cache_itr = hashed_index.find(id);
-  if (cache_itr != hashed_index.end()) {
-    return cache_itr->value;
-  }
-
-  // Check the large map
-  auto itr = vcd_count_map_.find(id);
-  if (itr != vcd_count_map_.end()) {
-    // Add to cache
-    cache_.insert({id, &itr->second});
-    evict_if_needed();
-    return &itr->second;
-  }
-
-  return nullptr;
-}
-
-
-
   const char *scope_;
   Network *sdc_network_;
   Report *report_;
@@ -233,12 +167,7 @@ VcdCounts* find(const std::string& id) {
   double time_scale_;
   VcdTime time_max_;
   VcdIdCountsMap vcd_count_map_;
-  //boost::unordered_map<std::string, VcdCounts> vcd_count_map_;
-  LRUCache cache_;
-  size_t cache_capacity_ = 100;
-
 };
-
 
 VcdCountReader::VcdCountReader(const char *scope,
                                Network *sdc_network,
@@ -363,9 +292,9 @@ VcdCountReader::varAppendValue(const string &id,
                                VcdTime time,
                                char value)
 {
-  auto itr = find(id);
-  if (itr) {
-    VcdCounts &vcd_counts = *itr;
+  auto itr = vcd_count_map_.find(id);
+  if (itr != vcd_count_map_.end()) {
+    VcdCounts &vcd_counts = itr->second;
     if (debug_->check("read_vcd_activities", 3)) {
       for (size_t bit_idx = 0; bit_idx < vcd_counts.size(); bit_idx++) {
         VcdCount &vcd_count = vcd_counts[bit_idx];
@@ -388,9 +317,9 @@ VcdCountReader::varAppendBusValue(const string &id,
                                   VcdTime time,
                                   int64_t bus_value)
 {
-  auto itr = find(id);
-  if (itr) {
-    VcdCounts &vcd_counts = *itr;
+  auto itr = vcd_count_map_.find(id);
+  if (itr != vcd_count_map_.end()) {
+    VcdCounts &vcd_counts = itr->second;
     for (size_t bit_idx = 0; bit_idx < vcd_counts.size(); bit_idx++) {
       char bit_value = ((bus_value >> bit_idx) & 0x1) ? '1' : '0';
       VcdCount &vcd_count = vcd_counts[bit_idx];

--- a/power/VcdReader.cc
+++ b/power/VcdReader.cc
@@ -26,6 +26,7 @@
 
 #include <inttypes.h>
 #include <set>
+#include "absl/container/flat_hash_map.h"
 
 #include "VcdParse.hh"
 #include "Debug.hh"
@@ -116,7 +117,8 @@ VcdCount::highTime(VcdTime time_max) const
 // VcdCount[bit]
 typedef vector<VcdCount> VcdCounts;
 // ID -> VcdCount[bit]
-typedef map<string, VcdCounts> VcdIdCountsMap;
+typedef absl::flat_hash_map<string, VcdCounts> VcdIdCountsMap;
+//typedef map<string, VcdCounts> VcdIdCountsMap;
 
 class VcdCountReader : public VcdReader
 {
@@ -305,8 +307,7 @@ VcdCountReader::varAppendValue(const string &id,
       }
     }
     for (size_t bit_idx = 0; bit_idx < vcd_counts.size(); bit_idx++) {
-      VcdCount &vcd_count = vcd_counts[bit_idx];
-      vcd_count.incrCounts(time, value);
+      vcd_counts[bit_idx].incrCounts(time, value);
     }
   }
 }


### PR DESCRIPTION
Checking in the debugger for a large .vcd file(320gByte), I see that all the time is spent in map::find().

Quick test for parsing large .vcd files, ca. 8x faster with `absl::flat_hash_map`

Tried std::unordered_map, but I could not tell a difference in performance.

Running a large test now that took ca. 14 hours, it runs in 109 minutes, so ca. 8x faster.

boost unrdered map, 198 minutes

Even with this improvement in in map::find(), most of the time does appear to be spend in the find() function, so perhaps there is an even more suitable map implementation for large .vcd files.

Perhaps a custom hashing function for std::map() would do the trick?

trying boost unordered flat map available in boost 1.83, looks like it will match absail unorderef flat map 104 minutes

