### PR TITLE
Avoid parallel build conflicts

### DIFF
--- a/liberty/LibertyParse.yy
+++ b/liberty/LibertyParse.yy
@@ -38,11 +38,12 @@
 #define loc_line(loc) loc.begin.line
 %}
 
-%require  "3.0"
+%require  "3.2"
 %skeleton "lalr1.cc"
 %debug
 %define api.namespace {sta}
 %locations
+%define api.location.file "LibertyLocation.hh"
 %define parse.assert
 %parse-param { LibertyScanner *scanner }
 %parse-param { LibertyParser *reader }

--- a/liberty/LibertyScanner.hh
+++ b/liberty/LibertyScanner.hh
@@ -30,7 +30,7 @@
 #include <FlexLexer.h>
 #endif
 
-#include "location.hh"
+#include "LibertyLocation.hh"
 #include "LibertyParse.hh"
 
 namespace sta {

--- a/sdf/SdfParse.yy
+++ b/sdf/SdfParse.yy
@@ -35,11 +35,12 @@
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 %}
 
-%require  "3.0"
+%require  "3.2"
 %skeleton "lalr1.cc"
 %debug
 %define api.namespace {sta}
 %locations
+%define api.location.file "SdfLocation.hh"
 %define parse.assert
 %parse-param { SdfScanner *scanner }
 %parse-param { SdfReader *reader }

--- a/sdf/SdfScanner.hh
+++ b/sdf/SdfScanner.hh
@@ -30,7 +30,7 @@
 #include <FlexLexer.h>
 #endif
 
-#include "location.hh"
+#include "SdfLocation.hh"
 #include "SdfParse.hh"
 
 namespace sta {

--- a/verilog/VerilogParse.yy
+++ b/verilog/VerilogParse.yy
@@ -48,11 +48,12 @@ sta::VerilogParse::error(const location_type &loc,
 }
 %}
 
-%require  "3.0"
+%require  "3.2"
 %skeleton "lalr1.cc"
 %debug
 %define api.namespace {sta}
 %locations
+%define api.location.file "VerilogLocation.hh"
 %define parse.assert
 %parse-param { VerilogScanner *scanner }
 %parse-param { VerilogReader *reader }

--- a/verilog/VerilogScanner.hh
+++ b/verilog/VerilogScanner.hh
@@ -30,7 +30,7 @@
 #include <FlexLexer.h>
 #endif
 
-#include "location.hh"
+#include "VerilogLocation.hh"
 #include "VerilogParse.hh"
 
 namespace sta {


### PR DESCRIPTION
The Liberty, Sdf, and Verilog parsers were writing to the same files causing random failures in parallel builds.  position.hh and stack.hh are removed by switching to 3.0 to 3.2 in the require statement. location.hh is renamed per-parser with api.location.file.