### PR TITLE
Update CentOS 7 Docker: Bison version bump to 3.8.2

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -2,7 +2,7 @@ FROM centos:centos7 AS base-dependencies
 LABEL author="James Cherry"
 LABEL maintainer="James Cherry <cherry@parallaxsw.com>"
 
-# Install dev and runtime dependencies
+# Install dev and runtime dependencies (use vault repos since mirror repos are discontinued)
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
     && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo \
@@ -11,8 +11,20 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
     && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo \ 
-    && yum install -y devtoolset-8 wget cmake3 make eigen3-devel tcl-devel tcl-tclreadline-devel swig3 bison flex zlib-devel valgrind \
+    && yum install -y devtoolset-11 wget cmake3 make eigen3-devel tcl-devel swig3 flex zlib-devel valgrind \
     && yum clean -y all
+
+# Download Bison
+RUN wget https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz && \
+    tar -xvf bison-3.8.2.tar.gz && \
+    rm bison-3.8.2.tar.gz
+
+# Build Bison
+RUN source /opt/rh/devtoolset-11/enable && \
+    cd bison-3.8.2 && \
+    ./configure && \
+    make -j`nproc` && \
+    make install
 
 # Download CUDD
 RUN wget https://raw.githubusercontent.com/davidkebo/cudd/main/cudd_versions/cudd-3.0.0.tar.gz && \
@@ -20,11 +32,12 @@ RUN wget https://raw.githubusercontent.com/davidkebo/cudd/main/cudd_versions/cud
     rm cudd-3.0.0.tar.gz
 
 # Build CUDD
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     cd cudd-3.0.0 && \
     mkdir ../cudd && \
     ./configure && \
-    make -j`nproc`
+    make -j`nproc` && \
+    make install
 
 FROM base-dependencies AS builder
 
@@ -33,9 +46,9 @@ WORKDIR /OpenSTA
 
 # Build
 RUN rm -rf build && mkdir build
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     cd build && \
-    cmake3 -DCUDD_DIR=../cudd-3.0.0 .. && \
+    cmake3 .. && \
     make -j`nproc`
 
 # Run sta on entry


### PR DESCRIPTION
**Main changes:**
- Removed `bison` from `yum install`
- Download and build `bison` from source directly from GNU FTP server

**Other small changes:**
- Remove optional package `tcl-tclreadline-devel`: unfortunately, this package is hosted on a flaky server and occasionally causes the Docker build to fail. Let me know if you'd like me to add a build from source or from RPM
- Install CUDD to system instead of directory
- Upgrade from `devtoolset-8` to `devtoolset-11`: upgrade to `gcc-11` and related tools

Please test on your end and let me know if it looks ok.