### PR TITLE
rename sta::source to sta::include to allow use of tcl source

### DIFF
--- a/app/StaMain.cc
+++ b/app/StaMain.cc
@@ -98,7 +98,7 @@ sourceTclFile(const char *filename,
 	      Tcl_Interp *interp)
 {
   string cmd;
-  stringPrint(cmd, "read_cmds %s%s%s",
+  stringPrint(cmd, "include %s%s%s",
 	      echo ? "-echo " : "",
 	      verbose ? "-verbose " : "",
 	      filename);

--- a/app/StaMain.cc
+++ b/app/StaMain.cc
@@ -90,7 +90,7 @@ findCmdLineKey(int &argc,
   return nullptr;
 }
 
-// Use overridden version of source to echo cmds and results.
+// Use custom source function to echo cmds and results.
 int
 sourceTclFile(const char *filename,
 	      bool echo,
@@ -98,7 +98,7 @@ sourceTclFile(const char *filename,
 	      Tcl_Interp *interp)
 {
   string cmd;
-  stringPrint(cmd, "source %s%s%s",
+  stringPrint(cmd, "read_cmds %s%s%s",
 	      echo ? "-echo " : "",
 	      verbose ? "-verbose " : "",
 	      filename);

--- a/sdc/Sdc.tcl
+++ b/sdc/Sdc.tcl
@@ -45,7 +45,7 @@ proc_redirect read_sdc {
   set prev_filename [info script]
   try {
     info script $filename
-    source_ $filename $echo 0
+    uplevel \#0 "sta::source_ $filename $echo 0"
   } finally {
     info script $prev_filename
   }
@@ -63,6 +63,7 @@ if { ![info exists renamed_source] } {
 }
 
 set ::sta_continue_on_error 0
+set ::sta_scoped_source 0
 
 define_cmd_args "source" \
   {[-echo] [-verbose] filename [> filename] [>> filename]}
@@ -79,7 +80,7 @@ proc_redirect source {
   set prev_filename [info script]
   try {
     info script $filename
-    source_ $filename $echo $verbose
+    uplevel 1 "sta::source_ $filename $echo $verbose"
   } finally {
     info script $prev_filename
   }
@@ -118,15 +119,23 @@ proc source_ { filename echo verbose } {
       if { [string index $line end] != "\\" \
 	     && [info complete $cmd] } {
 	set error {}
-	set error_code [catch {uplevel \#0 $cmd} result]
+  set source_uplevel "\#0"
+  if { $::sta_scoped_source } {
+    set source_uplevel "1"
+  }
+	set error_code [catch {uplevel $source_uplevel $cmd} result]
 	# cmd consumed
 	set cmd ""
 	# Flush results printed outside tcl to stdout/stderr.
 	fflush
+  
+  # error 2 should be {invoked "return" outside of a proc.} but early returns
+  # are actually supported by Tcl source, so we ignore the error here to emulate
+  # this behavior
 	switch $error_code {
 	  0 { if { $verbose && $result != "" } { report_line $result } }
 	  1 { set error $result }
-	  2 { set error {invoked "return" outside of a proc.} }
+	  2 { set error {} }
 	  3 { set error {invoked "break" outside of a loop.} }
 	  4 { set error {invoked "continue" outside of a loop.} }
 	}

--- a/test/regression.tcl
+++ b/test/regression.tcl
@@ -292,7 +292,7 @@ proc run_test_plain { test cmd_file log_file } {
     set run_file [test_run_file $test]
     set run_stream [open $run_file "w"]
     puts $run_stream "cd [file dirname $cmd_file]"
-    puts $run_stream "read_cmds [file tail $cmd_file]"
+    puts $run_stream "include [file tail $cmd_file]"
     if { $report_stats } {
       set stat_file [file normalize [test_stats_file $test]]
       puts $run_stream "sta::write_stats $stat_file"

--- a/test/regression.tcl
+++ b/test/regression.tcl
@@ -292,7 +292,7 @@ proc run_test_plain { test cmd_file log_file } {
     set run_file [test_run_file $test]
     set run_stream [open $run_file "w"]
     puts $run_stream "cd [file dirname $cmd_file]"
-    puts $run_stream "source [file tail $cmd_file]"
+    puts $run_stream "read_cmds [file tail $cmd_file]"
     if { $report_stats } {
       set stat_file [file normalize [test_stats_file $test]]
       puts $run_stream "sta::write_stats $stat_file"

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -152,6 +152,7 @@ record_sta_tests {
   report_json1
   report_json2
   scoped_source
+  source_sta_warn
   suppress_msg
   verilog_attribute
 }

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -151,6 +151,7 @@ record_sta_tests {
   report_checks_src_attr
   report_json1
   report_json2
+  scoped_source
   suppress_msg
   verilog_attribute
 }

--- a/test/scoped_source.ok
+++ b/test/scoped_source.ok
@@ -1,0 +1,2 @@
+Test String: foo
+Test String: bar

--- a/test/scoped_source.tcl
+++ b/test/scoped_source.tcl
@@ -2,7 +2,7 @@ set test_string foo
 
 proc source_file {} {
     set test_string bar
-    read_cmds ./scoped_sourceable.tcl
+    include ./scoped_sourceable.tcl
     source ./scoped_sourceable.tcl    
 }
 

--- a/test/scoped_source.tcl
+++ b/test/scoped_source.tcl
@@ -1,0 +1,12 @@
+set test_string foo
+
+proc source_file {} {
+    set test_string bar
+    source ./scoped_sourceable.tcl    
+}
+
+source_file
+
+set ::sta_scoped_source 1
+
+source_file

--- a/test/scoped_source.tcl
+++ b/test/scoped_source.tcl
@@ -2,11 +2,8 @@ set test_string foo
 
 proc source_file {} {
     set test_string bar
+    read_cmds ./scoped_sourceable.tcl
     source ./scoped_sourceable.tcl    
 }
-
-source_file
-
-set ::sta_scoped_source 1
 
 source_file

--- a/test/scoped_sourceable.tcl
+++ b/test/scoped_sourceable.tcl
@@ -1,0 +1,1 @@
+puts "Test String: $test_string"

--- a/test/source_sta_warn.ok
+++ b/test/source_sta_warn.ok
@@ -1,0 +1,2 @@
+Warning: sourced_sta_warn.tcl line 17, the line number here better be 17
+Error: sourced_sta_warn.tcl line 19, and this one? 19

--- a/test/source_sta_warn.tcl
+++ b/test/source_sta_warn.tcl
@@ -1,0 +1,1 @@
+source sourced_sta_warn.tcl

--- a/test/sourced_sta_warn.tcl
+++ b/test/sourced_sta_warn.tcl
@@ -1,0 +1,20 @@
+proc deepest {error} {
+    if { $error } {
+        ::sta::sta_error 3 "and this one? 19"
+    } else {
+        ::sta::sta_warn 2 "the line number here better be 17"
+    }
+}
+
+proc deeper {error} {
+    deepest $error
+}
+
+proc deep {error} {
+    deeper $error
+}
+
+deep 0
+
+catch {deep 1} error
+puts $error


### PR DESCRIPTION
- create new global stack, ::_sta_file_stack, to keep track of evaluated files (include and source)
- rename sta::source to sta::include, allowing the original tcl source (which behaves differently, including inheriting the caller's scope) to be used
- create new thin wrapper for tcl source as sta::source - all it does is push to and pop from ::_sta_file_stack
- update sta_error, sta_warn to inspect the stack and alter behavior based on whether the current file is sourced or included 

Original PR body follows:

---

- add new global variable, ::sta_scoped_source that if set to 1, causes all sourced files to be evaluated at the scope of the calling function instead of the top level (default 0). read_sdc will always be evaluated at the top-level, however.
- ignore early returns when sourcing files - tcl return is supposed to work when sourcing files. see https://www.tcl-lang.org/man/tcl8.6/TclCmd/return.htm for more info

---

I have chosen to make it opt-in behavior out of an excess of caution. The `~/.sta` issue could technically be resolved by upleveling `sourceTclFile`, but that may have unforeseen consequences. Fortunately, it's not a huge ask to ask users to set ::sta_scoped_source to 1 before package require statements.

Resolves #202 