### PR TITLE
Skip escape character instead of copying escaped one in SAIF reader

### DIFF
--- a/power/SaifReader.cc
+++ b/power/SaifReader.cc
@@ -196,9 +196,7 @@ SaifReader::unescaped(const char *token)
   string unescaped;
   for (const char *t = token; *t; t++) {
     char ch = *t;
-    if (ch == escape_)
-      unescaped += *(t+1);
-    else
+    if (ch != escape_)
       // Just the normal noises.
       unescaped += ch;
   }


### PR DESCRIPTION
This PR fixes removal of escape characters from SAIF identifiers. Current implementation resulted in doubling the escaped character instead of just skipping the escape one, which caused misinterpretation of ID without square brackets.

Before fix:
```
token resp_msg\[15\] -> resp_msg[[15]]
```

After fix:
```
token resp_msg\[15\] -> resp_msg[15]
```