### PR TITLE
Put generated StaConfig.hh into build artifacts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,6 @@ cmake-build-debug
 build
 pvt
 
-include/sta/StaConfig.hh
-
 app/sta
 app/libOpenSTA.*
 app/sta.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,7 +388,7 @@ message(STATUS "SSTA: ${SSTA}")
 
 # configure a header file to pass some of the CMake settings
 configure_file(${STA_HOME}/util/StaConfig.hh.cmake
-  ${STA_HOME}/include/sta/StaConfig.hh
+  ${CMAKE_CURRENT_BINARY_DIR}/include/sta/StaConfig.hh
   )
 
 ###########################################################
@@ -463,6 +463,7 @@ target_include_directories(sta_swig
   PRIVATE
   ${STA_HOME}
   ${TCL_INCLUDE_PATH}
+  ${CMAKE_CURRENT_BINARY_DIR}/include/sta
 )
 
 ###########################################################
@@ -514,6 +515,7 @@ target_include_directories(OpenSTA
   include
   ${TCL_INCLUDE_PATH}
   ${FLEX_INCLUDE_DIRS}
+  ${CMAKE_CURRENT_BINARY_DIR}/include/sta
 
   PRIVATE
   include/sta
@@ -581,6 +583,7 @@ install(TARGETS OpenSTA DESTINATION lib)
 
 # include
 install(DIRECTORY include/sta  DESTINATION include)
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/sta  DESTINATION include)
 
 ################################################################
 
@@ -588,6 +591,7 @@ add_custom_target(sta_tags etags -o TAGS
   ${STA_SOURCE}
   */*.hh
   include/sta/*.hh
+  ${CMAKE_CURRENT_BINARY_DIR}/include/sta/*.hh
   ${SWIG_FILES}
   ${STA_TCL_FILES}
   ${SWIG_TCL_FILES}


### PR DESCRIPTION
Before, the cmake configure_file() for the StaConfig.hh header, that make only sense for the particular cmake configuration as it contains specific defines for that build configuration, ended up in the original source tree.

With this fix, it is a build artifact inside build/.

Tested, that the final `make install` properly copies the StaConfig.hh to the correct location.