### PR TITLE
Fix behaviour mismatch between SAIF and VCD readers

### DIFF
--- a/power/SaifReader.cc
+++ b/power/SaifReader.cc
@@ -131,7 +131,7 @@ SaifReader::instancePush(const char *instance_name)
     bool first = true;
     for (string &inst : saif_scope_) {
       if (!first)
-        saif_scope += network_->pathDivider();
+        saif_scope += sdc_network_->pathDivider();
       saif_scope += inst;
       first = false;
     }
@@ -140,8 +140,8 @@ SaifReader::instancePush(const char *instance_name)
   }
   else {
     // Inside annotation scope.
-    Instance *parent = path_.empty() ? network_->topInstance() : path_.back();
-    Instance *child = network_->findChild(parent, instance_name);
+    Instance *parent = path_.empty() ? sdc_network_->topInstance() : path_.back();
+    Instance *child = sdc_network_->findChild(parent, instance_name);
     path_.push_back(child);
   }
   stringDelete(instance_name);
@@ -163,7 +163,7 @@ SaifReader::setNetDurations(const char *net_name,
                             SaifStateDurations &durations)
 {
   if (in_scope_level_ > 0) {
-    Instance *parent = path_.empty() ? network_->topInstance() : path_.back();
+    Instance *parent = path_.empty() ? sdc_network_->topInstance() : path_.back();
     if (parent) {
       string unescaped_name = unescaped(net_name);
       const Pin *pin = sdc_network_->findPin(parent, unescaped_name.c_str());


### PR DESCRIPTION
This PR fixes behaviour mismatch between reading VCD and SAIF. In the current implementation, OpenSTA fails to find some scopes while reading SAIF, even if the same scope path is found when reading a VCD file. This case can be seen with, i.e. `\dpath.b_reg.out[8]$_DFFE_PP_` variable. When reading from verilog, current implementation inserts escape characters before `[`, `]`, `\` and `/` if name is escaped at the beginning. This results in the scope name being stored as `dpath.b_reg.out\[8\]$_DFFE_PP_`, while some simulators remove this escape character and save scope name in VCD or SAIF as `dpath.b_reg.out[8]$_DFFE_PP_`. While VCD uses `SdcNetwork` which wraps `ConcreteNetwork` and tries to escape square brackets if it fails to find matching instance, SAIF reader uses `ConcreteNetwork` directly which results in scope not being found.