### PR TITLE
Fix levelize crash when vertices are enqueued in arrival/required iterators

### DIFF
--- a/search/Levelize.cc
+++ b/search/Levelize.cc
@@ -135,7 +135,7 @@ Levelize::levelize()
 
   findRoots();
   findBackEdges();
-  VertexSeq topo_sorted = findToplologicalOrder();
+  VertexSeq topo_sorted = findTopologicalOrder();
   assignLevels(topo_sorted);
   ensureLatchLevels();
 
@@ -345,7 +345,7 @@ Levelize::findUnvisitedVertices()
 ////////////////////////////////////////////////////////////////
 
 VertexSeq
-Levelize::findToplologicalOrder()
+Levelize::findTopologicalOrder()
 {
   Stats stats(debug_, report_);
   std::map<Vertex*, int> in_degree;

--- a/search/Levelize.cc
+++ b/search/Levelize.cc
@@ -130,7 +130,7 @@ Levelize::levelize()
     vertex->setVisited(false);
     vertex->setOnPath(false);
     // assignLevels init
-    vertex->setLevel(-1);
+    setLevel(vertex, -1);
   }
 
   findRoots();

--- a/search/Levelize.hh
+++ b/search/Levelize.hh
@@ -74,7 +74,7 @@ protected:
   void levelize();
   void findRoots();
   VertexSeq sortedRootsWithFanout();
-  VertexSeq findToplologicalOrder();
+  VertexSeq findTopologicalOrder();
   void assignLevels(VertexSeq &topo_sorted);
   void recordLoop(Edge *edge,
                   EdgeSeq &path);


### PR DESCRIPTION
Fix for re-levelization crashing if vertices are queued up in `search_->arrival_iter_` or `search_->required_iter_`.

The sequence leading up to the crash is the following:

 * Arrivals are computed, vertices are levelized.
 * The network is edited, some vertices are queued up in the arrival/required iterators. Levelization is invalidated (probably because a loop edge has been removed).
 * `sta_->ensureLevelized()` is called, internally `levelize()` sets level to -1 on a vertex without dequeuing it. Later on `Search::levelChangedBefore` attempts to remove the vertex from the queues but `BfsIterator::remove()` crashes when the vertex level is -1 (it uses a negative index into a vector).