### PR TITLE
Fix compiler warning about `if`

### DIFF
--- a/sdc/Sdc.cc
+++ b/sdc/Sdc.cc
@@ -3980,10 +3980,11 @@ Sdc::unrecordPathDelayInternalTo(ExceptionPath *exception)
     for (const Pin *pin : *to->pins()) {
       if (!(hasLibertyCheckTo(pin)
 	    || network_->isTopLevelPort(pin))
-	  && !pathDelayTo(pin))
+	  && !pathDelayTo(pin)) {
 	path_delay_internal_to_.erase(pin);
         if (exception->breakPath())
           path_delay_internal_to_break_.erase(pin);
+      }
     }
   }
 }


### PR DESCRIPTION
```
/home/ubuntu/actions-runner/_work/silisizer/third_party/OpenSTA/sdc/Sdc.cc: In member function ‘void sta::Sdc::unrecordPathDelayInternalTo(sta::ExceptionPath*)’:
/home/ubuntu/actions-runner/_work/silisizer/third_party/OpenSTA/sdc/Sdc.cc:3981:7: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
 3981 |       if (!(hasLibertyCheckTo(pin)
      |       ^~
/home/ubuntu/actions-runner/_work/silisizer/third_party/OpenSTA/sdc/Sdc.cc:3985:9: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
 3985 |         if (exception->breakPath())
      |         ^~
```