### PR TITLE
Add a less operator to BddPortVarMap

### DIFF
--- a/include/sta/Bdd.hh
+++ b/include/sta/Bdd.hh
@@ -34,7 +34,7 @@ struct DdManager;
 
 namespace sta {
 
-typedef std::map<const LibertyPort*, DdNode*> BddPortVarMap;
+typedef std::map<const LibertyPort*, DdNode*, LibertyPortLess> BddPortVarMap;
 typedef std::map<unsigned, const LibertyPort*> BddVarIdxPortMap;
 
 class Bdd : public StaState

--- a/include/sta/LibertyClass.hh
+++ b/include/sta/LibertyClass.hh
@@ -145,6 +145,12 @@ enum class TableAxisVariable {
 enum class PathType { clk, data, clk_and_data };
 const int path_type_count = 2;
 
+class LibertyPortLess
+{
+public:
+  bool operator()(const LibertyPort *port1, const LibertyPort *port2) const;
+};
+
 class LibertyPortNameLess
 {
 public:

--- a/liberty/Liberty.cc
+++ b/liberty/Liberty.cc
@@ -2819,6 +2819,13 @@ sortByName(const LibertyPortSet *set)
 }
 
 bool
+LibertyPortLess::operator()(const LibertyPort *port1,
+                            const LibertyPort *port2) const
+{
+  return LibertyPort::less(port1, port2);
+}
+
+bool
 LibertyPortNameLess::operator()(const LibertyPort *port1,
 				const LibertyPort *port2) const
 {


### PR DESCRIPTION
bdd_port_var_map_, of type BddPortVarMap, is iterated over in Power::evalBddActivity.  Previously the map used pointer comparison so the iteration order was non-deterministic.  The computed density was therefore non-deterministic due to the non-associativity of floating-point addition.