### PR TITLE
Allow backslash-EOL to end tokens in Liberty file

### DIFF
--- a/liberty/LibertyLex.ll
+++ b/liberty/LibertyLex.ll
@@ -78,7 +78,7 @@ TOKEN ({ALPHA}|{DIGIT}|_)({ALPHA}|{DIGIT}|[._\-])*(:({ALPHA}|{DIGIT}|_)+)?
 /* bus_naming_style : %s[%d] ; */
 BUS_STYLE "%s"{BUS_LEFT}"%d"{BUS_RIGHT}
 PUNCTUATION [,\:;|(){}+*&!'=]
-TOKEN_END {PUNCTUATION}|[ \t\r\n]
+TOKEN_END {PUNCTUATION}|[ \t\r\n]|\\{EOL}
 EOL \r?\n
 %%
 

--- a/test/liberty_backslash_eol.lib
+++ b/test/liberty_backslash_eol.lib
@@ -1,0 +1,65 @@
+library (liberty_backslash_eol) {
+  delay_model : "table_lookup";
+  simulation : false;
+  capacitive_load_unit\
+    (1,pF);
+  leakage_power_unit : "1pW";
+  current_unit : "1A";
+  pulling_resistance_unit : "1kohm";
+  time_unit : "1ns";
+  voltage_unit : "1v";
+  library_features : "report_delay_calculation";
+  input_threshold_pct_rise : 50;
+  input_threshold_pct_fall : 50;
+  output_threshold_pct_rise : 50;
+  output_threshold_pct_fall : 50;
+  slew_lower_threshold_pct_rise : 30;
+  slew_lower_threshold_pct_fall : 30;
+  slew_upper_threshold_pct_rise : 70;
+  slew_upper_threshold_pct_fall : 70;
+  slew_derate_from_library : 1.0;
+  nom_process : 1.0;
+  nom_temperature : 85.0;
+  nom_voltage : 0.75;
+  type (bus8) {
+    base_type : "array";
+    data_type : "bit";
+    bit_width : 8;
+    bit_from : 7;
+    bit_to : 0;
+  }
+  type (bus4) {
+    base_type : "array";
+    data_type : "bit";
+    bit_width : 4;
+    bit_from : 3;
+    bit_to : 0;
+  }
+
+  cell (my_inv) {
+    pin (A) {
+      capacitance : 1;
+      direction : "input";
+    }
+    pin (Y) {
+      function : "!A";
+      direction : "output";
+      timing () {
+        related_pin : "A";
+	      timing_sense : "negative_unate";
+        cell_rise (scalar) {
+          values ("1");
+        }
+        cell_fall (scalar) {
+          values ("1");
+        }
+        rise_transition (scalar) {
+          values ("1");
+        }
+        fall_transition (scalar) {
+          values ("1");
+        }
+      }
+    }
+  }
+}

--- a/test/liberty_backslash_eol.tcl
+++ b/test/liberty_backslash_eol.tcl
@@ -1,0 +1,2 @@
+# backslash eol should be ignored in liberty file
+read_liberty liberty_backslash_eol.lib

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -145,6 +145,7 @@ record_sta_tests {
   get_objrefs
   liberty_arcs_one2one_1
   liberty_arcs_one2one_2
+  liberty_backslash_eol
   liberty_ccsn
   liberty_latch3
   path_group_names


### PR DESCRIPTION
As mentioned in #277, I discovered an occurrence of the following in a commercial Liberty file:
```
ERROR: liberty.lib line 49, syntax error
```

Line 49:
```
receiver_capacitance_rise_threshold_pct\
       ( "0, 30.0, 50.0, 60.0, 70.0, 80.0, 90.0, 95.0, 100.00" );
   receiver_capacitance_fall_threshold_pct\
       ( "100, 70.0, 50.0, 40.0, 30.0, 20.0, 10.0, 5.0, 0.0" );
```

It seems that the lines are terminated with a backslash-EOL. This should be supported; it's a simple fix.

I added a test case to the regression that errors out before this PR and passes after it is applied. The syntax error is on line 4 `capacitive_load_unit`, which is also a complex attribute.