### PR TITLE
util: Fix memory leak in PatternMatch

### DIFF
--- a/util/PatternMatch.cc
+++ b/util/PatternMatch.cc
@@ -89,7 +89,9 @@ PatternMatch::compileRegexp()
   anchored_pattern += '$';
   Tcl_Obj *pattern_obj = Tcl_NewStringObj(anchored_pattern.c_str(),
 					  anchored_pattern.size());
+  Tcl_IncrRefCount(pattern_obj);
   regexp_ = Tcl_GetRegExpFromObj(interp_, pattern_obj, flags);
+  Tcl_DecrRefCount(pattern_obj);
   if (regexp_ == nullptr && interp_)
     throw RegexpCompileError(pattern_);
 }


### PR DESCRIPTION
When allocating a new string object in tcl you need to increment and then decrement the ref counter in order for objects to be correctly collected.