### PR TITLE
Fix truncating a list of paths with `-sort_by_slack` flag enabled

### DIFF
--- a/search/PathGroup.cc
+++ b/search/PathGroup.cc
@@ -546,8 +546,6 @@ PathGroups::makePathEnds(ExceptionTo *to,
   pushGroupPathEnds(path_ends);
   if (sort_by_slack) {
     sort(path_ends, PathEndLess(this));
-    if (static_cast<int>(path_ends.size()) > group_path_count_)
-      path_ends.resize(group_path_count_);
   }
 
   if (unconstrained_paths

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -156,6 +156,7 @@ record_sta_tests {
   report_json2
   suppress_msg
   verilog_attribute
+  report_checks_sorted
 }
 
 define_test_group fast [group_tests all]

--- a/test/report_checks_sorted.ok
+++ b/test/report_checks_sorted.ok
@@ -1,0 +1,87 @@
+Startpoint: r1 (rising edge-triggered flip-flop clocked by clk)
+Endpoint: r4 (rising edge-triggered flip-flop clocked by clk)
+Path Group: long
+Path Type: max
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock clk (rise edge)
+   0.00    0.00   clock network delay (ideal)
+   0.00    0.00 ^ r1/CLK (DFFHQx4_ASAP7_75t_R)
+  64.76   64.76 ^ r1/Q (DFFHQx4_ASAP7_75t_R)
+  17.77   82.53 ^ u2/Y (BUFx2_ASAP7_75t_R)
+  17.88  100.42 ^ u3/Y (BUFx2_ASAP7_75t_R)
+  16.66  117.08 ^ u4/Y (BUFx2_ASAP7_75t_R)
+   0.00  117.08 ^ r4/D (DFFHQx4_ASAP7_75t_R)
+         117.08   data arrival time
+
+ 500.00  500.00   clock clk (rise edge)
+   0.00  500.00   clock network delay (ideal)
+   0.00  500.00   clock reconvergence pessimism
+         500.00 ^ r4/CLK (DFFHQx4_ASAP7_75t_R)
+ -12.61  487.39   library setup time
+         487.39   data required time
+---------------------------------------------------------
+         487.39   data required time
+        -117.08   data arrival time
+---------------------------------------------------------
+         370.32   slack (MET)
+
+
+Startpoint: r1 (rising edge-triggered flip-flop clocked by clk)
+Endpoint: r3 (rising edge-triggered flip-flop clocked by clk)
+Path Group: custom
+Path Type: max
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock clk (rise edge)
+   0.00    0.00   clock network delay (ideal)
+   0.00    0.00 ^ r1/CLK (DFFHQx4_ASAP7_75t_R)
+  64.76   64.76 ^ r1/Q (DFFHQx4_ASAP7_75t_R)
+  17.77   82.53 ^ u2/Y (BUFx2_ASAP7_75t_R)
+  17.88  100.42 ^ u3/Y (BUFx2_ASAP7_75t_R)
+   0.00  100.42 ^ r3/D (DFFHQx4_ASAP7_75t_R)
+         100.42   data arrival time
+
+ 500.00  500.00   clock clk (rise edge)
+   0.00  500.00   clock network delay (ideal)
+   0.00  500.00   clock reconvergence pessimism
+         500.00 ^ r3/CLK (DFFHQx4_ASAP7_75t_R)
+ -12.98  487.02   library setup time
+         487.02   data required time
+---------------------------------------------------------
+         487.02   data required time
+        -100.42   data arrival time
+---------------------------------------------------------
+         386.60   slack (MET)
+
+
+Startpoint: r1 (rising edge-triggered flip-flop clocked by clk)
+Endpoint: r2 (rising edge-triggered flip-flop clocked by clk)
+Path Group: clk
+Path Type: max
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock clk (rise edge)
+   0.00    0.00   clock network delay (ideal)
+   0.00    0.00 ^ r1/CLK (DFFHQx4_ASAP7_75t_R)
+  64.76   64.76 ^ r1/Q (DFFHQx4_ASAP7_75t_R)
+  17.77   82.53 ^ u2/Y (BUFx2_ASAP7_75t_R)
+   0.00   82.53 ^ r2/D (DFFHQx4_ASAP7_75t_R)
+          82.53   data arrival time
+
+ 500.00  500.00   clock clk (rise edge)
+   0.00  500.00   clock network delay (ideal)
+   0.00  500.00   clock reconvergence pessimism
+         500.00 ^ r2/CLK (DFFHQx4_ASAP7_75t_R)
+ -12.98  487.02   library setup time
+         487.02   data required time
+---------------------------------------------------------
+         487.02   data required time
+         -82.53   data arrival time
+---------------------------------------------------------
+         404.48   slack (MET)
+
+

--- a/test/report_checks_sorted.tcl
+++ b/test/report_checks_sorted.tcl
@@ -1,0 +1,12 @@
+# report_checks with sorted path ends
+read_liberty asap7_small.lib.gz
+read_verilog report_checks_sorted.v
+link_design top
+
+create_clock -name clk -period 500 {clk}
+set_input_delay -clock clk 0 {in}
+
+group_path -name custom -to {r3}
+group_path -name long -to {r4}
+
+report_checks -group_path_count 1 -sort_by_slack

--- a/test/report_checks_sorted.v
+++ b/test/report_checks_sorted.v
@@ -1,0 +1,15 @@
+module top (input in, input clk, output out);
+
+  wire w1, w2, w3, w4;
+
+  DFFHQx4_ASAP7_75t_R r1 (.D(in), .CLK(clk), .Q(w1));
+
+  BUFx2_ASAP7_75t_R u2 (.A(w1), .Y(w2));
+  BUFx2_ASAP7_75t_R u3 (.A(w2), .Y(w3));
+  BUFx2_ASAP7_75t_R u4 (.A(w3), .Y(w4));
+  
+  DFFHQx4_ASAP7_75t_R r2 (.D(w2), .CLK(clk), .Q(out));
+  DFFHQx4_ASAP7_75t_R r3 (.D(w3), .CLK(clk), .Q(out));
+  DFFHQx4_ASAP7_75t_R r4 (.D(w4), .CLK(clk), .Q(out));
+
+endmodule


### PR DESCRIPTION
This PR fixes a bug where the OpenSTA was truncating a list of paths with the `-sort_by_slack` flag enabled. The list was resized to the number of paths per group, even if there were multiple path groups involved.