### PR TITLE
Use STA_HOME instead of CMAKE_SOURCE_DIR when generating messages.txt file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -613,6 +613,6 @@ add_custom_target(sta_tags
 add_custom_command(
   TARGET OpenSTA
   POST_BUILD
-  COMMAND ${CMAKE_SOURCE_DIR}/etc/FindMessages.tcl > ${CMAKE_SOURCE_DIR}/doc/messages.txt || true
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  COMMAND ${STA_HOME}/etc/FindMessages.tcl > ${STA_HOME}/doc/messages.txt || true
+  WORKING_DIRECTORY ${STA_HOME}
 )


### PR DESCRIPTION
When using OpenSTA as a submodule/external dependency, `CMAKE_SOURCE_DIR` resolves to the root of the top project instead of OpenSTA's. Using `STA_HOME` resolves the path correctly and is used in other places in the project already.