### PR TITLE
Mark choice of delay implementation with IWYU export pragma.

### DIFF
--- a/include/sta/Delay.hh
+++ b/include/sta/Delay.hh
@@ -26,6 +26,7 @@
 
 #include "StaConfig.hh"
 
+// IWYU pragma: begin_exports
 #if (SSTA == 1)
   // Delays are Normal PDFs.
   #include "DelayNormal1.hh"
@@ -36,6 +37,7 @@
   // Delays are floats.
   #include "DelayFloat.hh"
 #endif
+// IWYU pragma: end_exports
 
 namespace sta {
 


### PR DESCRIPTION
The Delay header is meant to provide the Delay implementation to whoever is including it; it chooses the right implementation via an include which this PR marks as providing a symbol that is to be exported.

Without that annotation, tools such as `clang-tidy` or the `clangd` language server (as well as many other tools) will complain about headers not directly providing a symbol if users just include Delay.hh; With this annotation, they know.

Documentation about these IWYU pragmas:
https://clangd.llvm.org/design/include-cleaner#iwyu-pragmas https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-begin_exportsend_exports