### PR TITLE
Package require test

### DIFF
--- a/test/package_require.tcl
+++ b/test/package_require.tcl
@@ -1,0 +1,3 @@
+package require http
+package require msgcat
+package require opt

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -149,6 +149,7 @@ record_sta_tests {
   liberty_ccsn
   liberty_float_as_str
   liberty_latch3
+  package_require
   path_group_names
   prima3
   report_checks_src_attr


### PR DESCRIPTION
A simple regression test to ensure that packages can be loaded without error. This test was failing before the changes to the `source`/`include` TCL procs were made.