### PR TITLE
Include StaConfig.hh once

### DIFF
--- a/util/StaConfig.hh.cmake
+++ b/util/StaConfig.hh.cmake
@@ -1,5 +1,4 @@
-#ifndef STA_CONFIG_HH
-#define STA_CONFIG_HH
+#pragma once
 
 #define STA_VERSION "${STA_VERSION}"
 
@@ -10,5 +9,3 @@
 #define SSTA ${SSTA}
 
 #define TCL_READLINE ${TCL_READLINE}
-
-#endif


### PR DESCRIPTION
This was causing issues with a CentOS 7 configuration with an older compiler/cmake.