### PR TITLE
Thread local tag cache

### DIFF
--- a/include/sta/Search.hh
+++ b/include/sta/Search.hh
@@ -72,6 +72,8 @@ typedef Vector<VertexSlackMap> VertexSlackMapSeq;
 typedef Vector<WorstSlacks> WorstSlacksSeq;
 typedef std::vector<DelayDbl> DelayDblSeq;
 
+class ThreadLocalCacheTagSet;
+
 class Search : public StaState
 {
 public:
@@ -627,7 +629,7 @@ protected:
   ClkInfoSet *clk_info_set_;
   std::mutex clk_info_lock_;
   // Use pointer to tag set so Tag.hh does not need to be included.
-  TagSet *tag_set_;
+  ThreadLocalCacheTagSet *tag_set_;
   // Entries in tags_ may be missing where previous filter tags were deleted.
   TagIndex tag_capacity_;
   std::atomic<Tag **> tags_;


### PR DESCRIPTION
Add a thread local cache in  of findTag to reduce lock contention.
`findTag` spends ~90% of its time contending on the lock. This pr lowers
that significantly, taking findTag from 3.9% of wall time to 0.8%.

There will be a small amount of Tag* leakage until the threads are
destroyed at which point the thread local caches will be automatically
cleaned up.