### PR TITLE
Change DispatchQueue::dispatch to use notify_one.

### DIFF
--- a/util/DispatchQueue.cc
+++ b/util/DispatchQueue.cc
@@ -66,7 +66,7 @@ DispatchQueue::dispatch(const fp_t& op)
   // Manual unlocking is done before notifying, to avoid waking up
   // the waiting thread only to block again (see notify_one for details)
   lock.unlock();
-  cv_.notify_all();
+  cv_.notify_one();
 }
 
 void
@@ -79,7 +79,7 @@ DispatchQueue::dispatch(fp_t&& op)
   // Manual unlocking is done before notifying, to avoid waking up
   // the waiting thread only to block again (see notify_one for details)
   lock.unlock();
-  cv_.notify_all();
+  cv_.notify_one();
 }
 
 void


### PR DESCRIPTION
This prevents the thundering herd problem and should increase the scalability of the DispatchQueue significantly.

Additionally the code the DispatchQueue was taken from made this improvement five years ago:
https://github.com/embeddedartistry/embedded-resources/commit/79ad8a539d7e264350464e434e03b5d910ae4a29