### PR TITLE
util: Add method to get thread count from dispatch queue

### DIFF
--- a/include/sta/DispatchQueue.hh
+++ b/include/sta/DispatchQueue.hh
@@ -24,6 +24,7 @@ public:
   DispatchQueue(size_t thread_cnt);
   ~DispatchQueue();
   void setThreadCount(size_t thread_count);
+  size_t getThreadCount() const;
   // Dispatch and copy.
   void dispatch(const fp_t& op);
   // Dispatch and move.

--- a/util/DispatchQueue.cc
+++ b/util/DispatchQueue.cc
@@ -49,6 +49,12 @@ DispatchQueue::setThreadCount(size_t thread_count)
   }
 }
 
+size_t
+DispatchQueue::getThreadCount() const
+{
+  return threads_.size();
+}
+
 void
 DispatchQueue::finishTasks()
 {


### PR DESCRIPTION
I'm looking to try to have unified thread pool with OpenSTA and OpenROAD and having this method would make it easier to understand how much parallelism is available in the pool.