### PR TITLE
Fix `isBuffer`

### DIFF
--- a/include/sta/PortDirection.hh
+++ b/include/sta/PortDirection.hh
@@ -41,7 +41,6 @@ public:
   static PortDirection *internal() { return internal_; }
   static PortDirection *ground() { return ground_; }
   static PortDirection *power() { return power_; }
-  static PortDirection *well() { return well_; }
   static PortDirection *unknown() { return unknown_; }
   static PortDirection *find(const char *dir_name);
   const char *name() const { return name_; }
@@ -60,8 +59,6 @@ public:
   bool isPower() const { return this == power_; }
   // Ground or power.
   bool isPowerGround() const;
-  // Nwell, pwell, deepnwell, or deeppwell.
-  bool isWell() const { return this == well_; }
   bool isInternal() const { return this == internal_; }
   bool isUnknown() const { return this == unknown_; }
 
@@ -79,7 +76,6 @@ private:
   static PortDirection *internal_;
   static PortDirection *ground_;
   static PortDirection *power_;
-  static PortDirection *well_;
   static PortDirection *unknown_;
 };
 

--- a/liberty/Liberty.cc
+++ b/liberty/Liberty.cc
@@ -1226,7 +1226,7 @@ LibertyCell::bufferPorts(// Return values.
       }
       output = port;
     }
-    else if (!dir->isPowerGround() && !dir->isWell()) {
+    else if (!port->isPwrGnd()) {
         // Invalid direction.
 	input = nullptr;
 	output = nullptr;

--- a/liberty/LibertyReader.cc
+++ b/liberty/LibertyReader.cc
@@ -5700,12 +5700,6 @@ LibertyReader::visitPgType(LibertyAttr *attr)
     case PwrGndType::internal_power:
       dir = PortDirection::power();
       break;
-    case PwrGndType::nwell:
-    case PwrGndType::pwell:
-    case PwrGndType::deepnwell:
-    case PwrGndType::deeppwell:
-      dir = PortDirection::well();
-      break;
     case PwrGndType::none:
       libError(1291, attr, "unknown pg_type.");
       break;

--- a/network/PortDirection.cc
+++ b/network/PortDirection.cc
@@ -35,7 +35,6 @@ PortDirection *PortDirection::bidirect_;
 PortDirection *PortDirection::internal_;
 PortDirection *PortDirection::ground_;
 PortDirection *PortDirection::power_;
-PortDirection *PortDirection::well_;
 PortDirection *PortDirection::unknown_;
 
 void
@@ -48,8 +47,7 @@ PortDirection::init()
   internal_ = new PortDirection("internal", 4);
   ground_ = new PortDirection("ground", 5);
   power_ = new PortDirection("power", 6);
-  well_ = new PortDirection("well", 7);
-  unknown_ = new PortDirection("unknown", 8);
+  unknown_ = new PortDirection("unknown", 7);
 }
 
 void
@@ -69,8 +67,6 @@ PortDirection::destroy()
   ground_ = nullptr;
   delete power_;
   power_ = nullptr;
-  delete well_;
-  well_ = nullptr;
   delete unknown_;
   unknown_ = nullptr;
 }
@@ -99,8 +95,6 @@ PortDirection::find(const char *dir_name)
     return ground_;
   else if (stringEqual(dir_name, "power"))
     return power_;
-  else if (stringEqual(dir_name, "well"))
-    return well_;
   else
     return nullptr;
 }

--- a/power/Power.cc
+++ b/power/Power.cc
@@ -1506,7 +1506,6 @@ Power::findUnannotatedPins(const Instance *inst,
     LibertyPort *liberty_port = sdc_network_->libertyPort(pin);
     if (!network_->direction(pin)->isInternal()
 	&& !network_->direction(pin)->isPowerGround()
-        && !network_->direction(pin)->isWell()
 	&& !(liberty_port && liberty_port->isPwrGnd())
         && user_activity_map_.find(pin) == user_activity_map_.end())
       unannotated_pins.push_back(pin);
@@ -1528,7 +1527,6 @@ Power::pinCount()
       LibertyPort *liberty_port = sdc_network_->libertyPort(pin);
       if (!network_->direction(pin)->isInternal()
 	  && !network_->direction(pin)->isPowerGround()
-          && !network_->direction(pin)->isWell()
 	  && !(liberty_port && liberty_port->isPwrGnd()))
         count++;
     }

--- a/power/VcdReader.cc
+++ b/power/VcdReader.cc
@@ -290,7 +290,6 @@ VcdCountReader::addVarPin(const string &pin_name,
       && !sdc_network_->isHierarchical(pin)
       && !sdc_network_->direction(pin)->isInternal()
       && !sdc_network_->direction(pin)->isPowerGround()
-      && !sdc_network_->direction(pin)->isWell()
       && !(liberty_port && liberty_port->isPwrGnd())) {
     VcdCounts &vcd_counts = vcd_count_map_[id];
     vcd_counts.resize(width);


### PR DESCRIPTION
I discovered a bug when one of our tests failed on `is_buffer` property check on SKY130. It's clearly a buffer but is marked as a non-buffer because of the wells in SKY130. I've included a minimal example in the `tests/` directory.

This PR adds a `PortDirection` enum value for wells (`nwell`, `pwell`, `deepnwell`, `deeppwell`) and ignores them in a couple places where they should be ignored (I just searched for `isPowerGround()` and evaluated whether wells should be ignored at those places).

Let me know if any changes are needed. Thanks!