### PR TITLE
Get the pin count from the Liberty cell not the Cell

### DIFF
--- a/verilog/VerilogReader.cc
+++ b/verilog/VerilogReader.cc
@@ -534,7 +534,7 @@ VerilogReader::makeModuleInst(const string *module_vname,
   // to reduce the memory footprint of the verilog parser.
   if (liberty_cell
       && hasScalarNamedPortRefs(liberty_cell, pins)) {
-    int port_count = network_->portBitCount(cell);
+    const int port_count = liberty_cell->portBitCount();
     StdStringSeq net_names(port_count);
     for (VerilogNet *vnet : *pins) {
       VerilogNetPortRefScalarNet *vpin =


### PR DESCRIPTION
The Cell may come from LEF which doesn't have internal pins that Liberty does.  This used to work by dumb luck where the extra two power pins in LEF happened to align to the extra two internal pins from Liberty.  With the change to pg_pins this no longer works.