### PR TITLE
Fix C++20 warning

### DIFF
--- a/search/Sta.cc
+++ b/search/Sta.cc
@@ -5241,8 +5241,8 @@ Sta::slowDrivers(int count)
 {
   findDelays();
   InstanceSeq insts = network_->leafInstances();
-  sort(insts, [=] (const Instance *inst1,
-                   const Instance *inst2) {
+  sort(insts, [this] (const Instance *inst1,
+                      const Instance *inst2) {
     return delayGreater(instMaxSlew(inst1, this),
                         instMaxSlew(inst2, this),
                         this);

--- a/spice/WriteSpice.cc
+++ b/spice/WriteSpice.cc
@@ -533,8 +533,8 @@ WriteSpice::writeParasiticNetwork(const Pin *drvr_pin,
   // Sort resistors for consistent regression results.
   ParasiticResistorSeq resistors = parasitics_->resistors(parasitic);
   sort(resistors.begin(), resistors.end(),
-       [=] (const ParasiticResistor *r1,
-            const ParasiticResistor *r2) {
+       [this] (const ParasiticResistor *r1,
+               const ParasiticResistor *r2) {
          return parasitics_->id(r1) < parasitics_->id(r2);
        });
   for (ParasiticResistor *resistor : resistors) {
@@ -577,8 +577,8 @@ WriteSpice::writeParasiticNetwork(const Pin *drvr_pin,
   // Sort nodes for consistent regression results.
   ParasiticNodeSeq nodes = parasitics_->nodes(parasitic);
   sort(nodes.begin(), nodes.end(),
-       [=] (const ParasiticNode *node1,
-            const ParasiticNode *node2) {
+       [this] (const ParasiticNode *node1,
+               const ParasiticNode *node2) {
          const char *name1 = parasitics_->name(node1);
          const char *name2 = parasitics_->name(node2);
          return stringLess(name1, name2);
@@ -598,8 +598,8 @@ WriteSpice::writeParasiticNetwork(const Pin *drvr_pin,
   // Sort coupling capacitors for consistent regression results.
   ParasiticCapacitorSeq capacitors = parasitics_->capacitors(parasitic);
   sort(capacitors.begin(), capacitors.end(),
-       [=] (const ParasiticCapacitor *c1,
-            const ParasiticCapacitor *c2) {
+       [this] (const ParasiticCapacitor *c1,
+               const ParasiticCapacitor *c2) {
          return parasitics_->id(c1) < parasitics_->id(c2);
        });
   const Net *net = pinNet(drvr_pin, network_);

--- a/verilog/VerilogReader.cc
+++ b/verilog/VerilogReader.cc
@@ -146,8 +146,8 @@ VerilogReader::VerilogReader(NetworkReader *network) :
   zero_net_name_("zero_"),
   one_net_name_("one_")
 {
-  network->setLinkFunc([=] (const char *top_cell_name,
-                            bool make_black_boxes) -> Instance* {
+  network->setLinkFunc([this] (const char *top_cell_name,
+                               bool make_black_boxes) -> Instance* {
     return linkNetwork(top_cell_name, make_black_boxes, true);
   });
   constant10_max_ = stdstrPrint("%llu", std::numeric_limits<VerilogConstant10>::max());


### PR DESCRIPTION
warning: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]