### PR TITLE
Support Input/output internal power

### DIFF
--- a/include/sta/PowerClass.hh
+++ b/include/sta/PowerClass.hh
@@ -78,16 +78,22 @@ public:
   PowerResult();
   void clear();
   float internal() const { return internal_; }
+  float inputinternal() const { return inputinternal_; }
+  float outputinternal() const { return outputinternal_; }
   float switching() const { return switching_; }
   float leakage() const { return leakage_; }
   float total() const;
   void incr(PowerResult &result);
   void incrInternal(float pwr);
+  void incrInputInternal(float pwr);
+  void incrOutputInternal(float pwr);
   void incrSwitching(float pwr);
   void incrLeakage(float pwr);
 
 private:
   float internal_;
+  float inputinternal_;
+  float outputinternal_;
   float switching_;
   float leakage_;
 };

--- a/include/sta/PowerClass.hh
+++ b/include/sta/PowerClass.hh
@@ -78,8 +78,8 @@ public:
   PowerResult();
   void clear();
   float internal() const { return internal_; }
-  float inputinternal() const { return inputinternal_; }
-  float outputinternal() const { return outputinternal_; }
+  float inputInternal() const { return input_internal_; }
+  float outputInternal() const { return output_internal_; }
   float switching() const { return switching_; }
   float leakage() const { return leakage_; }
   float total() const;
@@ -92,8 +92,8 @@ public:
 
 private:
   float internal_;
-  float inputinternal_;
-  float outputinternal_;
+  float input_internal_;
+  float output_internal_;
   float switching_;
   float leakage_;
 };

--- a/power/Power.cc
+++ b/power/Power.cc
@@ -1615,19 +1615,19 @@ Power::deletePinBefore(const Pin *)
 
 PowerResult::PowerResult() :
   internal_(0.0),
-  inputinternal_(0.0),
-  outputinternal_(0.0),
+  input_internal_(0.0),
+  output_internal_(0.0),
   switching_(0.0),
   leakage_(0.0)
 {
 }
 
 void
-PowerResult::clear() 
+PowerResult::clear()
 {
   internal_ = 0.0;
-  inputinternal_ = 0.0;
-  outputinternal_ = 0.0;
+  input_internal_ = 0.0;
+  output_internal_ = 0.0;
   switching_ = 0.0;
   leakage_ = 0.0;
 }
@@ -1646,13 +1646,13 @@ PowerResult::incrInternal(float pwr)
 void
 PowerResult::incrInputInternal(float pwr)
 {
-  inputinternal_ += pwr;
+  input_internal_ += pwr;
 }
 
 void
 PowerResult::incrOutputInternal(float pwr)
 {
-  outputinternal_ += pwr;
+  output_internal_ += pwr;
 }
 
 void
@@ -1671,8 +1671,8 @@ void
 PowerResult::incr(PowerResult &result)
 {
   internal_ += result.internal_;
-  inputinternal_ += result.inputinternal_;
-  outputinternal_ += result.outputinternal_;
+  input_internal_ += result.input_internal_;
+  output_internal_ += result.output_internal_;
   switching_ += result.switching_;
   leakage_ += result.leakage_;
 }

--- a/power/Power.cc
+++ b/power/Power.cc
@@ -1103,9 +1103,9 @@ Power::findOutputInternalPower(const LibertyPort *to_port,
   FuncExpr *func = to_port->function();
 
   map<const char*, float, StringLessIf> pg_duty_sum;
-  int numArcs = 0;
+  int arc_count = 0;
   for (InternalPower *pwr : corner_cell->internalPowers(to_corner_port)) {
-    numArcs += 1;
+    arc_count += 1;
     const LibertyPort *from_corner_port = pwr->relatedPort();
     if (from_corner_port) {
       const Pin *from_pin = findLinkPin(inst, from_corner_port);
@@ -1116,8 +1116,8 @@ Power::findOutputInternalPower(const LibertyPort *to_port,
       pg_duty_sum[related_pg_pin] += from_density * duty;
     }
   }
-  // The number of pins that consume internal power in total
-  float numInternalPowerPins = numArcs / (float) pg_duty_sum.size();
+  // The number of pins that consume internal power in total.
+  float internal_power_pin_count = arc_count / (float) pg_duty_sum.size();
 
   debugPrint(debug_, "power", 2,
              "             when act/ns  duty  wgt   energy    power");
@@ -1178,8 +1178,8 @@ Power::findOutputInternalPower(const LibertyPort *to_port,
     out_internal += avg_arc_internal;
   }
   result.incrInternal(internal);
-  if (numInternalPowerPins)
-    result.incrOutputInternal(out_internal / numInternalPowerPins);
+  if (internal_power_pin_count)
+    result.incrOutputInternal(out_internal / internal_power_pin_count);
   else
     result.incrOutputInternal(0.0);
 }

--- a/power/Power.i
+++ b/power/Power.i
@@ -46,6 +46,13 @@ pushPowerResultFloats(PowerResult &power,
   powers.push_back(power.leakage());
   powers.push_back(power.total());
 }
+static void
+pushInternalPowerComponents(PowerResult &power,
+                          FloatSeq &powers)
+{
+  powers.push_back(power.inputinternal());
+  powers.push_back(power.outputinternal());
+}
 
 FloatSeq
 design_power(const Corner *corner)
@@ -59,6 +66,16 @@ design_power(const Corner *corner)
   pushPowerResultFloats(clock, powers);
   pushPowerResultFloats(macro, powers);
   pushPowerResultFloats(pad, powers);
+  return powers;
+}
+
+FloatSeq
+internal_power_components(const Corner *corner)
+{
+  PowerResult total, sequential, combinational, clock, macro, pad;
+  Sta::sta()->power(corner, total, sequential, combinational, clock, macro, pad);
+  FloatSeq powers;
+  pushInternalPowerComponents(total, powers);
   return powers;
 }
 

--- a/power/Power.i
+++ b/power/Power.i
@@ -50,8 +50,8 @@ static void
 pushInternalPowerComponents(PowerResult &power,
                           FloatSeq &powers)
 {
-  powers.push_back(power.inputinternal());
-  powers.push_back(power.outputinternal());
+  powers.push_back(power.inputInternal());
+  powers.push_back(power.outputInternal());
 }
 
 FloatSeq

--- a/power/Power.tcl
+++ b/power/Power.tcl
@@ -69,6 +69,19 @@ proc_redirect report_power {
   }
 }
 
+define_cmd_args "report_internal_power_components" { [> filename] [>> filename] }
+proc_redirect report_internal_power_components {
+  global sta_report_default_digits
+  # Set the default corner
+  set corner [cmd_corner]
+  if { ![liberty_libraries_exist] } {
+    sta_error 304 "No liberty libraries have been read."
+  }
+  set power_result [internal_power_components $corner]
+  report_line $power_result
+}
+
+
 proc liberty_libraries_exist {} {
   set lib_iter [liberty_library_iterator]
   set have_liberty 0

--- a/power/Power.tcl
+++ b/power/Power.tcl
@@ -69,19 +69,6 @@ proc_redirect report_power {
   }
 }
 
-define_cmd_args "report_internal_power_components" { [> filename] [>> filename] }
-proc_redirect report_internal_power_components {
-  global sta_report_default_digits
-  # Set the default corner
-  set corner [cmd_corner]
-  if { ![liberty_libraries_exist] } {
-    sta_error 304 "No liberty libraries have been read."
-  }
-  set power_result [internal_power_components $corner]
-  report_line $power_result
-}
-
-
 proc liberty_libraries_exist {} {
   set lib_iter [liberty_library_iterator]
   set have_liberty 0


### PR DESCRIPTION
Adds support for querying both input and output internal power in gate power analysis.

Features:
- Added `get_input_internal_power()` and `get_output_internal_power()` commands
- Fixes NaN output by using zero for unavailable internal power values

Based on Silimate/OpenSTA implementation with upstream integration.