### PR TITLE
Allow `set_units`/`set_cmd_units` to support floats properly

### DIFF
--- a/sdc/Sdc.tcl
+++ b/sdc/Sdc.tcl
@@ -144,7 +144,7 @@ proc check_unit { unit key suffix key_var } {
     set arg_suffix [string range $value end-[expr $suffix_length - 1] end]
     if { [string match -nocase $arg_suffix $suffix] } {
       set arg_prefix [string range $value 0 end-$suffix_length]
-      if { [regexp "^(10*)?(\[Mkmunpf\])?$" $arg_prefix ignore mult prefix] } {
+      if { [regexp "^(10*\.?0*)?(\[Mkmunpf\])?$" $arg_prefix ignore mult prefix] } {
         if { $mult == "" } {
           set mult 1
         }

--- a/tcl/CmdUtil.tcl
+++ b/tcl/CmdUtil.tcl
@@ -167,13 +167,13 @@ proc set_unit_values { unit key suffix key_var } {
     set arg_suffix [string range $value end-[expr $suffix_length - 1] end]
     if { [string match -nocase $arg_suffix $suffix] } {
       set arg_prefix [string range $value 0 end-$suffix_length]
-      if { [regexp "^(10*)?(\[Mkmunpf\])?$" $arg_prefix ignore mult prefix] } {
+      if { [regexp "^(10*\.?0*)?(\[Mkmunpf\])?$" $arg_prefix ignore mult prefix] } {
         #puts "$arg_prefix '$mult' '$prefix'"
         if { $mult == "" } {
           set mult 1
         }
         set scale [unit_prefix_scale $unit $prefix ]
-        set_cmd_unit_scale $unit $scale
+        set_cmd_unit_scale $unit [expr $scale * $mult]
       } else {
         sta_error 166 "unknown unit $unit prefix '${arg_prefix}'."
       }

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -158,6 +158,7 @@ record_sta_tests {
   report_checks_src_attr
   report_json1
   report_json2
+  set_units_float
   suppress_msg
   verilog_attribute
   verilog_specify

--- a/test/set_units_float.ok
+++ b/test/set_units_float.ok
@@ -1,0 +1,7 @@
+ time 1ns
+ capacitance 1pF
+ resistance 1kohm
+ voltage 1v
+ current 1A
+ power 1W
+ distance 1um

--- a/test/set_units_float.tcl
+++ b/test/set_units_float.tcl
@@ -1,0 +1,21 @@
+# set_units with floating point numbers
+
+# start by setting the cmd units
+set_cmd_units -capacitance 1000.0fF
+set_cmd_units -resistance 1.0kohm
+set_cmd_units -time 1.0ns
+set_cmd_units -voltage 1.0v
+set_cmd_units -current 1.0A
+set_cmd_units -distance 1.0um
+
+# then check the units
+set_units -capacitance 1.0pF
+set_units -resistance 1.0kohm
+set_units -time 1.0ns
+set_units -voltage 1.0v
+set_units -current 1.0A
+set_units -power 1.0W
+set_units -distance 1.0um
+
+# finally report the units
+report_units


### PR DESCRIPTION
This fixes two issues:
1. `set_units` and `set_cmd_units` do not support floats. One of customers had this in their SDC file: `set_units -capacitance 1000.0fF`
2. The multiplier in `set_cmd_units` does not have any effect. For example, `1000.0fF` would result in `1e-15` overall scaling as opposed to the expected `1e-12`.

This PR also includes a test case that can be used to reproduce the issues (fails before PR, passes after).