### PR TITLE
Smallfixes for set_units_float regexes

### DIFF
--- a/sdc/Sdc.tcl
+++ b/sdc/Sdc.tcl
@@ -144,7 +144,7 @@ proc check_unit { unit key suffix key_var } {
     set arg_suffix [string range $value end-[expr $suffix_length - 1] end]
     if { [string match -nocase $arg_suffix $suffix] } {
       set arg_prefix [string range $value 0 end-$suffix_length]
-      if { [regexp "^(10*\\\.?0*)?(\[Mkmunpf\])?$" $arg_prefix ignore mult prefix] } {
+      if { [regexp "^(10*\\.?0*)?(\[Mkmunpf\])?$" $arg_prefix ignore mult prefix] } {
         if { $mult == "" } {
           set mult 1
         }

--- a/tcl/CmdUtil.tcl
+++ b/tcl/CmdUtil.tcl
@@ -167,7 +167,7 @@ proc set_unit_values { unit key suffix key_var } {
     set arg_suffix [string range $value end-[expr $suffix_length - 1] end]
     if { [string match -nocase $arg_suffix $suffix] } {
       set arg_prefix [string range $value 0 end-$suffix_length]
-      if { [regexp "^(10*\.?0*)?(\[Mkmunpf\])?$" $arg_prefix ignore mult prefix] } {
+      if { [regexp "^(10*\\.?0*)?(\[Mkmunpf\])?$" $arg_prefix ignore mult prefix] } {
         #puts "$arg_prefix '$mult' '$prefix'"
         if { $mult == "" } {
           set mult 1

--- a/test/set_units_float.tcl
+++ b/test/set_units_float.tcl
@@ -3,18 +3,18 @@
 # start by setting the cmd units
 set_cmd_units -capacitance 1000.0fF
 set_cmd_units -resistance 1.0kohm
-set_cmd_units -time 1.0ns
+set_cmd_units -time 1ns
 set_cmd_units -voltage 1.0v
-set_cmd_units -current 1.0A
-set_cmd_units -distance 1.0um
+set_cmd_units -current 1.00A
+set_cmd_units -distance 1.000um
 
 # then check the units
 set_units -capacitance 1.0pF
 set_units -resistance 1.0kohm
 set_units -time 1.0ns
-set_units -voltage 1.0v
-set_units -current 1.0A
-set_units -power 1.0W
+set_units -voltage 1v
+set_units -current 1.00A
+set_units -power 1.000W
 set_units -distance 1.0um
 
 # finally report the units


### PR DESCRIPTION
The backslashes need to be escaped on both regexes. Also updated the test cases to catch this.