### PR TITLE
Expose 'TimingType' from `TimingArc`.

### DIFF
--- a/include/sta/TimingArc.hh
+++ b/include/sta/TimingArc.hh
@@ -171,6 +171,7 @@ public:
   void deleteTimingArc(TimingArc *arc);
   TimingArc *findTimingArc(unsigned arc_index);
   void setRole(const TimingRole *role);
+  TimingType timingType() const { return attrs_->timingType(); }
   FuncExpr *cond() const { return attrs_->cond(); }
   // Cond default is the timing arcs with no condition when there are
   // other conditional timing arcs between the same pins.


### PR DESCRIPTION
When using the OpenSTA Liberty file parser as a general-purpose Liberty reader, it's useful to be able to extract the original `TimingType` for a timing arc, and trivial to support.