### PR TITLE
Write verilog escape fix

### DIFF
--- a/network/VerilogNamespace.cc
+++ b/network/VerilogNamespace.cc
@@ -88,15 +88,12 @@ staToVerilog(const char *sta_name)
   for (const char *s = sta_name; *s ; s++) {
     char ch = s[0];
     if (ch == verilog_escape) {
+      escaped = true;
       char next_ch = s[1];
       if (next_ch == verilog_escape) {
-        escaped_name += ch;
         escaped_name += next_ch;
         s++;
       }
-      else
-        // Skip escape.
-        escaped = true;
     }
     else {
       if ((!(isalnum(ch) || ch == '_')))
@@ -126,15 +123,13 @@ staToVerilog2(const char *sta_name)
   for (const char *s = sta_name; *s ; s++) {
     char ch = s[0];
     if (ch == verilog_escape) {
+      escaped = true;
       char next_ch = s[1];
       if (next_ch == verilog_escape) {
         escaped_name += ch;
         escaped_name += next_ch;
         s++;
       }
-      else
-        // Skip escape.
-        escaped = true;
     }
     else {
       bool is_brkt = (ch == bus_brkt_left || ch == bus_brkt_right);

--- a/network/VerilogNamespace.cc
+++ b/network/VerilogNamespace.cc
@@ -126,7 +126,6 @@ staToVerilog2(const char *sta_name)
       escaped = true;
       char next_ch = s[1];
       if (next_ch == verilog_escape) {
-        escaped_name += ch;
         escaped_name += next_ch;
         s++;
       }

--- a/test/helpers.tcl
+++ b/test/helpers.tcl
@@ -1,0 +1,41 @@
+# Helper functions common to multiple regressions.
+
+set test_dir [file dirname [file normalize [info script]]]
+set result_dir [file join $test_dir "results"]
+
+# puts [exec cat $file] without forking.
+proc report_file { file } {
+  set stream [open $file r]
+  if { [file extension $file] == ".gz" } {
+    zlib push gunzip $stream
+  }
+  gets $stream line
+  while { ![eof $stream] } {
+    puts $line
+    gets $stream line
+  }
+  close $stream
+}
+
+proc report_file_filter { file filter } {
+  set stream [open $file r]
+  gets $stream line
+  while { ![eof $stream] } {
+    set index [string first $filter $line]
+    if { $index != -1 } {
+      set line [string replace $line $index [expr $index + [string length $filter] - 1]]
+    }
+    puts $line
+    gets $stream line
+  }
+  close $stream
+}
+
+proc make_result_file { filename } {
+  variable result_dir
+  return [file join $result_dir $filename]
+}
+
+proc sort_objects { objects } {
+  return [sta::sort_by_full_name $objects]
+}

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -165,6 +165,7 @@ record_public_tests {
   suppress_msg
   verilog_attribute
   verilog_specify
+  verilog_write_escape
 }
 
 define_test_group fast [group_tests all]

--- a/test/verilog_write_escape.ok
+++ b/test/verilog_write_escape.ok
@@ -1,0 +1,18 @@
+module multi_sink (clk);
+ input clk;
+
+ wire \alu_adder_result_ex[0] ;
+
+ hier_block \h1\x  (.childclk(clk),
+    .\Y[2:1] ({\alu_adder_result_ex[0] ,
+    \alu_adder_result_ex[0] }));
+endmodule
+module hier_block (childclk,
+    \Y[2:1] );
+ input childclk;
+ output [1:0] \Y[2:1] ;
+
+
+ BUFx2_ASAP7_75t_R \abuf_$100  (.A(childclk));
+ BUFx2_ASAP7_75t_R \ff0/name  (.A(childclk));
+endmodule

--- a/test/verilog_write_escape.tcl
+++ b/test/verilog_write_escape.tcl
@@ -1,0 +1,14 @@
+# Check if "h1\x" and \Y[2:1] are correctly processed from input to output of Verilog
+read_liberty gf180mcu_sram.lib.gz
+read_liberty asap7_small.lib.gz
+read_verilog verilog_write_escape.v
+link_design multi_sink
+set output_file "verilog_write_escape_out.v"
+write_verilog $output_file
+set fp [open $output_file r]
+while {[gets $fp line] >= 0} {
+    puts $line
+}
+close $fp
+read_verilog $output_file
+file delete $output_file

--- a/test/verilog_write_escape.tcl
+++ b/test/verilog_write_escape.tcl
@@ -1,14 +1,10 @@
 # Check if "h1\x" and \Y[2:1] are correctly processed from input to output of Verilog
+source helpers.tcl
 read_liberty gf180mcu_sram.lib.gz
 read_liberty asap7_small.lib.gz
 read_verilog verilog_write_escape.v
 link_design multi_sink
-set output_file "verilog_write_escape_out.v"
-write_verilog $output_file
-set fp [open $output_file r]
-while {[gets $fp line] >= 0} {
-    puts $line
-}
-close $fp
-read_verilog $output_file
-file delete $output_file
+set verilog_file [make_result_file "write_verilog1.v"]
+write_verilog $verilog_file
+report_file $verilog_file
+read_verilog $verilog_file

--- a/test/verilog_write_escape.v
+++ b/test/verilog_write_escape.v
@@ -1,0 +1,13 @@
+module \multi_sink (clk);
+ input clk;
+ wire \alu_adder_result_ex[0] ;
+ \hier_block \h1\x (.childclk(clk),  .\Y[2:1] ({ \alu_adder_result_ex[0] , \alu_adder_result_ex[0]  }) );
+endmodule // multi_sink
+
+module \hier_block (childclk, \Y[2:1] );
+   input childclk; 
+   output [1:0] \Y[2:1] ;
+   wire [1:0] \Y[2:1] ;
+   BUFx2_ASAP7_75t_R \abuf_$100  (.A(childclk));
+   BUFx2_ASAP7_75t_R \ff0/name (.A(childclk));
+endmodule // hier_block1

--- a/test/verilog_write_escape.v
+++ b/test/verilog_write_escape.v
@@ -1,10 +1,10 @@
-module \multi_sink (clk);
+module multi_sink (clk);
  input clk;
  wire \alu_adder_result_ex[0] ;
  \hier_block \h1\x (.childclk(clk),  .\Y[2:1] ({ \alu_adder_result_ex[0] , \alu_adder_result_ex[0]  }) );
 endmodule // multi_sink
 
-module \hier_block (childclk, \Y[2:1] );
+module hier_block (childclk, \Y[2:1] );
    input childclk; 
    output [1:0] \Y[2:1] ;
    wire [1:0] \Y[2:1] ;

--- a/verilog/VerilogWriter.cc
+++ b/verilog/VerilogWriter.cc
@@ -389,7 +389,8 @@ VerilogWriter::writeInstBusPin(const Instance *inst,
   if (!first_port)
     fprintf(stream_, ",\n    ");
 
-  fprintf(stream_, ".%s({", network_->name(port));
+  string port_vname = portVerilogName(network_->name(port)); 
+  fprintf(stream_, ".%s({", port_vname.c_str());
   first_port = false;
   bool first_member = true;
 


### PR DESCRIPTION
Fix for https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/3826

There are 2 src file changes and one testcase added in test/ directory to verify the golden output (.ok file)

src/sta/verilog/VerilogWriter.cc
VerilogWriter::writeInstBusPin was using the portname directly from the Network object instead of converting to a verilog name. So we need to write this string port_vname = portVerilogName(network_->name(port)) instead of network_->name(port) in the output verilog. This fixed the issue when the portname was getting the extra escapes like Y\\[32:1\\] instead of Y[32:1] in the Verilog that was written out by write_verilog (read_verilog shows error when encountering Y\\[32:1\\] which is now fixed)

src/sta/network/VerilogNamespace.cc
staToVerilog function that converts the sta names to Verilog names was keeping double escape sequence as is. So for example, a hierarchical cell \a\x in original verilog produced by Yosys, would mistakenly get written out as a\\\x by write_verilog (read_verilog shows error when encountering a\\\x which is now fixed). The bug in this function is due to an inconsistency with the verilogToSta function that adds escape to any existing escape sequence. So unescaping logic wasn't consistent, i.e., not removing the extra "\\". I have also updated the staToVerilog2 function accordingly for completion.


**Details of fix in src/sta/network/VerilogNamespace.cc explaining the unescaping logic and the small bug I fixed there.**

The escaping logic was implemented in verilogToSta function. If any name in the Verilog input began with a "\\" it is considered an escaped name. In such a name, if either of "[" or "]" or "/" or "" is encountered, an extra "\\" is added and the leading "\\"  is skipped when storing as sta_name that is understood by code.

There was a bug in the "unescaping" logic.

Now when we convert from sta_name to a verilog name via staToVerilog or staToVerilog2 (to write into Verilog output), it should be inverse of the verilogToSta, i.e., if we encounter any "\\" in the name, it means it was escaped, so needs to be unescaped before writing as a verilog name.
Note that Read_verilog would have failed if user had a name like h1\\\x in the original Verilog instead of \h1\x. So anytime we encounter "\\" in staToVerilog or staToVerilog2, it MUST have been escaped by verilogToSta function

Unescaping logic is as follows

if any character in sta_name was "\\", meaning it was escaped, the following needs to be done :
(1) we must set "escaped" to true. --> This was incomplete because when even if next char was "\\" escaped must be true
(2) if character after "\\" was also another "\\", we should skip double escape and just write a single "\\",--> This was a fix as previously double escaping was done causing read_verilog failure
(3) if character after "\\" was not another "\\", then we don't do anything with current "\\" and proceed with next character, so if sta_name was like a\\/x, when looking at "\\", next character is "/", so we skip this iteration of the loop and don't write "\\", and in next iter just go into the else block of if (ch == verilog_escape) block. This is where there is slight difference in staToVerilog and staToVerilog2 though decision is almost the same

staToVerilog sees current character as "/" in the else block and it is neither alphanumeric nor "_", so marks as escaped=true and writes this character as is. This is called for module and instance names.

staToVerilog2 (that is called for bus and ports), sees current character as "/" in the else block which satisfies this complicated looking if condition, so marks escaped as true and writes this character "/": The big condition is basically saying that "ch" is considered escaped if it is either a square bracket, or it is neither a square bracket nor alphanumeric nor "". So a "[" or "]" or "$" or any special character other than "\\" would result in escaped=true.
And if the character was escaped, extra space is added- I think this was to fix an old issue.
If character was not escaped, then the original sta_name is written out in the verilog.

Ideally, we could just keep the logic of staToVerilog2 since it is a superset of staToVerilog but that would a bigger change.