### PR TITLE
Revert duplicate timingType() declaration in TimingArcSet

### DIFF
--- a/include/sta/TimingArc.hh
+++ b/include/sta/TimingArc.hh
@@ -170,7 +170,6 @@ public:
   void deleteTimingArc(TimingArc *arc);
   TimingArc *findTimingArc(unsigned arc_index);
   void setRole(const TimingRole *role);
-  TimingType timingType() const { return attrs_->timingType(); }
   FuncExpr *cond() const { return attrs_->cond(); }
   // Cond default is the timing arcs with no condition when there are
   // other conditional timing arcs between the same pins.


### PR DESCRIPTION
Now the `TimingArcSet` class in `TimingArc.hh` has two identical declarations of the `timingType()` member function with the same signature, return type and implementation, which causes an overload conflict error during the build process.

This reverts commit f0c9971015015fa9cded7d2c1427bee55718ddfb.

## Related Issue
#389 

## Related PR
#380 