### PR TITLE
Handle MT issues in setVertexArrivals, fix non-deterministic crash

### DIFF
--- a/search/Levelize.cc
+++ b/search/Levelize.cc
@@ -88,6 +88,7 @@ Levelize::clear()
     delete loop;
   loops_.clear();
   loop_edges_.clear();
+  latch_d_to_q_edges_.clear();
   max_level_ = 0;
 }
 
@@ -520,6 +521,18 @@ Levelize::assignLevels(VertexSeq &topo_sorted)
 // This is because the Q arrival depends on the D arrival and
 // to find them in parallel they have to be scheduled separately
 // to avoid a race condition.
+// latch_d_to_q_edges_ is kept as a persistent set across incremental
+// relevelizations (cleared only by clear() on full re-levelize).
+// This is necessary because during incremental relevelize() only the
+// D vertices that happen to be visited accumulate edges into
+// latch_d_to_q_edges_ via visit().  If Q's clock path is relevelize'd
+// (Q.level changes to equal D.level) without touching D's data path,
+// D is never visited and its DtoQ edge would be absent from a
+// transient set — leaving the D/Q level collision undetected.
+// By keeping the set persistent and removing edges only when they are
+// deleted (see deleteEdgeBefore), every incremental ensureLatchLevels
+// sees all live latch DtoQ edges regardless of which vertices were
+// visited in the current run.
 void
 Levelize::ensureLatchLevels()
 {
@@ -529,7 +542,6 @@ Levelize::ensureLatchLevels()
     if (from->level() == to->level())
       setLevel(from, from->level() + level_space_);
   }
-  latch_d_to_q_edges_.clear();
 }
 
 void


### PR DESCRIPTION
Issue 1
[Rapidus hercules_idecode hits non-deterministic STA assertion · Issue #1537 · The-OpenROAD-Project-private/OpenROAD-flow-scripts](https://github.com/The-OpenROAD-Project-private/OpenROAD-flow-scripts/issues/1537)
Non-deterministic segmentation fault in GRT

```
sta::Path::vertexPath
sta::ArrivalVisitor::pruneCrprArrivals
sta::ArrivalVisitor::visit
sta::DispatchQueue::dispatch_thread_handler
```
Issue 2
[Rapidus hercules_is_int with M4D1 parasitics hits STA assertion · Issue #1526 · The-OpenROAD-Project-private/OpenROAD-flow-scripts](https://github.com/The-OpenROAD-Project-private/OpenROAD-flow-scripts/issues/1526)
Non-deterministic STA assert in CTS (most-shallow stack same as above)

```
sta::CheckCrpr::findCrpr
sta::Latches::latchBorrowInfo
sta::Latches::latchRequired
sta::Latches::latchOutArrival
sta::PathVisitor::visitFromPath
sta::PathVisitor::visitEdge
sta::PathVisitor::visitFaninPaths
sta::ArrivalVisitor::visit
```
Both happen because setVertexArrivals() unconditionally mutates vertex->paths_ with no protection, while the multi-threaded BFS allows other threads to simultaneously read another vertex's path array  through the CRPR clock path lookup (crprClkPath() → Path::vertexPath()). The two crashes represent the same data race manifesting at different points in the call:

Crash in Issue 1 fails immediately in  vertexPath,
Crash in Issue 2 uses a transiently valid pointer that becomes dangling before findCrpr dereferences it, producing garbage that overflows the genclk_src_paths_ vector index.

To fix this, we defer deletion of old vertex path arrays until after visitParallel completes. 
So in setVertexArrivals, instead of immediately deleting the old path array (which frees memory that concurrent CRPR/latch readers may still hold pointers to), save it to a per-search list and free it in deleteTagsPrev() — which is called only after all threads for a level have finished.

**Why this fixes both crashes** ?

Issue 1 (Path::vertexPath ← pruneCrprArrivals):
  Thread B was freeing Vclk->paths_ via deletePaths()/makePaths() while Thread A read Vclk->paths_[path_index]. The old array is now kept alive until deleteTagsPrev(), so Thread A's pointer is always
  valid within the parallel level.

Issue 2  ('\_n < size()' ← findCrpr ← latchBorrowInfo):
  Thread A obtained a const Path *src_clk_path via crprClkPath() pointing into Vclk->paths\_. Thread B freed that array. Dereferencing the dangling pointer produced garbage rf/min_max indices, which overflowed the genclk_src_paths_ vector. With deferred deletion the returned pointer stays valid, so findCrpr reads correct data.