### PR TITLE
Make `wire_load_tree_` default to unknown so we can detect when it's not present in a Liberty file.

### DIFF
--- a/liberty/Liberty.cc
+++ b/liberty/Liberty.cc
@@ -3042,7 +3042,7 @@ OperatingConditions::OperatingConditions(const char *name) :
   Pvt(0.0, 0.0, 0.0),
   name_(name),
   // Default wireload tree.
-  wire_load_tree_(WireloadTree::balanced)
+  wire_load_tree_(WireloadTree::unknown)
 {
 }
 

--- a/parasitics/Parasitics.cc
+++ b/parasitics/Parasitics.cc
@@ -257,12 +257,12 @@ Parasitics::makeWireloadNetwork(const Pin *drvr_pin,
         makeWireloadNetworkWorst(parasitic, drvr_pin, net, wireload_cap,
                                  wireload_res, fanout);
         break;
+      case WireloadTree::unknown:
       case WireloadTree::balanced:
         makeWireloadNetworkBalanced(parasitic, drvr_pin, wireload_cap, wireload_res,
                                     fanout);
         break;
       case WireloadTree::best_case:
-      case WireloadTree::unknown:
         makeWireloadNetworkBest(parasitic, drvr_pin, wireload_cap, wireload_res,
                                 fanout);
         break;


### PR DESCRIPTION
This is potentially a behavior change, but I think omitting this from the Liberty file is rare. I've only seen it in some DTCD Liberty files. In those Liberty libraries, it seems to be expected that the Liberty data is valid for all `WireloadTree` types. Thus it is necessary to distinguish between "wire load tree was specified as 'balanced'" and "wire load tree was not specified".