### PR TITLE
Use `Tcl_Size` for all tcl functions returning sizes.

### DIFF
--- a/tcl/StaTclTypes.i
+++ b/tcl/StaTclTypes.i
@@ -280,7 +280,7 @@ using namespace sta;
 }
 
 %typemap(in) std::string_view {
-  int length;
+  Tcl_Size length;
   const char *str = Tcl_GetStringFromObj($input, &length);
   $1 = std::string_view(str, length);
 }
@@ -415,7 +415,7 @@ using namespace sta;
 }
 
 %typemap(in) Transition* {
-  int length;
+  Tcl_Size length;
   const char *arg = Tcl_GetStringFromObj($input, &length);
   Transition *tr = Transition::find(std::string_view(arg, length));
   if (tr == nullptr) {
@@ -433,7 +433,7 @@ using namespace sta;
 }
 
 %typemap(in) RiseFall* {
-  int length;
+  Tcl_Size length;
   const char *arg = Tcl_GetStringFromObj($input, &length);
   const RiseFall *rf = RiseFall::find(std::string_view(arg, length));
   if (rf == nullptr) {
@@ -451,7 +451,7 @@ using namespace sta;
 }
 
 %typemap(in) RiseFallBoth* {
-  int length;
+  Tcl_Size length;
   const char *arg = Tcl_GetStringFromObj($input, &length);
   const RiseFallBoth *rf = RiseFallBoth::find(std::string_view(arg, length));
   if (rf == nullptr) {
@@ -469,7 +469,7 @@ using namespace sta;
 }
 
 %typemap(in) PortDirection* {
-  int length;
+  Tcl_Size length;
   const char *arg = Tcl_GetStringFromObj($input, &length);
   PortDirection *dir = PortDirection::find(arg);
   if (dir == nullptr) {
@@ -481,7 +481,7 @@ using namespace sta;
  }
 
 %typemap(in) TimingRole* {
-  int length;
+  Tcl_Size length;
   const char *arg = Tcl_GetStringFromObj($input, &length);
   const TimingRole *role = TimingRole::find(arg);
   if (role)
@@ -498,7 +498,7 @@ using namespace sta;
 }
 
 %typemap(in) LogicValue {
-  int length;
+  Tcl_Size length;
   std::string arg = Tcl_GetStringFromObj($input, &length);
   if (arg == "0" || stringEqual(arg, "zero"))
     $1 = LogicValue::zero;
@@ -517,7 +517,7 @@ using namespace sta;
 }
 
 %typemap(in) AnalysisType {
-  int length;
+  Tcl_Size length;
   const char *arg = Tcl_GetStringFromObj($input, &length);
   if (stringEqual(arg, "single"))
     $1 = AnalysisType::single;
@@ -831,7 +831,7 @@ using namespace sta;
 }
 
 %typemap(in) MinMax* {
-  int length;
+  Tcl_Size length;
   char *arg = Tcl_GetStringFromObj($input, &length);
   // Swig is retarded and drops const on args.
   MinMax *min_max = const_cast<MinMax*>(MinMax::find(arg));
@@ -852,7 +852,7 @@ using namespace sta;
 }
 
 %typemap(in) MinMaxAll* {
-  int length;
+  Tcl_Size length;
   char *arg = Tcl_GetStringFromObj($input, &length);
   // Swig is retarded and drops const on args.
   MinMaxAll *min_max = const_cast<MinMaxAll*>(MinMaxAll::find(arg));
@@ -865,7 +865,7 @@ using namespace sta;
 }
 
 %typemap(in) MinMaxAllNull* {
-  int length;
+  Tcl_Size length;
   char *arg = Tcl_GetStringFromObj($input, &length);
   if (stringEqual(arg, "NULL"))
     $1 = nullptr;
@@ -887,7 +887,7 @@ using namespace sta;
 
 // SetupHold is typedef'd to MinMax.
 %typemap(in) const SetupHold* {
-  int length;
+  Tcl_Size length;
   char *arg = Tcl_GetStringFromObj($input, &length);
   // Swig is retarded and drops const on args.
   if (stringEqual(arg, "hold")
@@ -904,7 +904,7 @@ using namespace sta;
 
 // SetupHoldAll is typedef'd to MinMaxAll.
 %typemap(in) const SetupHoldAll* {
-  int length;
+  Tcl_Size length;
   char *arg = Tcl_GetStringFromObj($input, &length);
   // Swig is retarded and drops const on args.
   if (stringEqual(arg, "hold")
@@ -925,7 +925,7 @@ using namespace sta;
 
 // EarlyLate is typedef'd to MinMax.
 %typemap(in) const EarlyLate* {
-  int length;
+  Tcl_Size length;
   char *arg = Tcl_GetStringFromObj($input, &length);
   // Swig is retarded and drops const on args.
   EarlyLate *early_late = const_cast<EarlyLate*>(EarlyLate::find(arg));
@@ -939,7 +939,7 @@ using namespace sta;
 
 // EarlyLateAll is typedef'd to MinMaxAll.
 %typemap(in) const EarlyLateAll* {
-  int length;
+  Tcl_Size length;
   char *arg = Tcl_GetStringFromObj($input, &length);
   // Swig is retarded and drops const on args.
   EarlyLateAll *early_late = const_cast<EarlyLateAll*>(EarlyLateAll::find(arg));
@@ -952,7 +952,7 @@ using namespace sta;
 }
 
 %typemap(in) TimingDerateType {
-  int length;
+  Tcl_Size length;
   char *arg = Tcl_GetStringFromObj($input, &length);
   if (stringEqual(arg, "net_delay"))
     $1 = TimingDerateType::net_delay;
@@ -967,7 +967,7 @@ using namespace sta;
 }
 
 %typemap(in) TimingDerateCellType {
-  int length;
+  Tcl_Size length;
   char *arg = Tcl_GetStringFromObj($input, &length);
   if (stringEqual(arg, "cell_delay"))
     $1 = TimingDerateCellType::cell_delay;
@@ -980,7 +980,7 @@ using namespace sta;
 }
 
 %typemap(in) PathClkOrData {
-  int length;
+  Tcl_Size length;
   std::string arg = Tcl_GetStringFromObj($input, &length);
   if (stringEqual(arg, "clk"))
     $1 = PathClkOrData::clk;
@@ -993,7 +993,7 @@ using namespace sta;
 }
 
 %typemap(in) ReportSortBy {
-  int length;
+  Tcl_Size length;
   std::string arg = Tcl_GetStringFromObj($input, &length);
   if (stringEqual(arg, "group"))
     $1 = sort_by_group;
@@ -1006,7 +1006,7 @@ using namespace sta;
 }
 
 %typemap(in) ReportPathFormat {
-  int length;
+  Tcl_Size length;
   std::string arg = Tcl_GetStringFromObj($input, &length);
   if (stringEqual(arg, "full"))
     $1 = ReportPathFormat::full;
@@ -1188,7 +1188,7 @@ using namespace sta;
   if (Tcl_ListObjGetElements(interp, $input, &argc, &argv) == TCL_OK
       && argc > 0) {
     for (int i = 0; i < argc; i++) {
-      int length;
+      Tcl_Size length;
       const char *mode_name = Tcl_GetStringFromObj(argv[i], &length);
       Mode *mode = sta->findMode(mode_name);
       if (mode)
@@ -1215,7 +1215,7 @@ using namespace sta;
 
 %typemap(in) Scene* {
   sta::Sta *sta = Sta::sta();
-  int length;
+  Tcl_Size length;
   std::string scene_name = Tcl_GetStringFromObj($input, &length);
   // parse_scene_or_all support depreated 11/21/2025
   if (scene_name == "NULL")
@@ -1248,7 +1248,7 @@ using namespace sta;
   if (Tcl_ListObjGetElements(interp, $input, &argc, &argv) == TCL_OK
       && argc > 0) {
     for (int i = 0; i < argc; i++) {
-      int length;
+      Tcl_Size length;
       const char *scene_name = Tcl_GetStringFromObj(argv[i], &length);
       Scene *scene = sta->findScene(scene_name);
       if (scene)
@@ -1274,7 +1274,7 @@ using namespace sta;
 }
 
 %typemap(in) PropertyValue {
-  int length;
+  Tcl_Size length;
   const char *arg = Tcl_GetStringFromObj($input, &length);
   $1 = PropertyValue(arg);
 }
@@ -1411,7 +1411,7 @@ using namespace sta;
 }
 
 %typemap(in) CircuitSim {
-  int length;
+  Tcl_Size length;
   std::string arg = Tcl_GetStringFromObj($input, &length);
   if (stringEqual(arg, "hspice"))
     $1 = CircuitSim::hspice;

--- a/tcl/TclTypeHelpers.cc
+++ b/tcl/TclTypeHelpers.cc
@@ -40,7 +40,7 @@ tclListStringSeq(Tcl_Obj *const source,
   StringSeq seq;
   if (Tcl_ListObjGetElements(interp, source, &argc, &argv) == TCL_OK) {
     for (int i = 0; i < argc; i++) {
-      int length;
+      Tcl_Size length;
       const char *str = Tcl_GetStringFromObj(argv[i], &length);
       seq.push_back(str);
     }
@@ -58,7 +58,7 @@ tclListStringSeqPtr(Tcl_Obj *const source,
   if (Tcl_ListObjGetElements(interp, source, &argc, &argv) == TCL_OK) {
     StringSeq *seq = new StringSeq;
     for (int i = 0; i < argc; i++) {
-      int length;
+      Tcl_Size length;
       const char *str = Tcl_GetStringFromObj(argv[i], &length);
       seq->push_back(str);
     }
@@ -78,7 +78,7 @@ tclListStringSet(Tcl_Obj *const source,
   if (Tcl_ListObjGetElements(interp, source, &argc, &argv) == TCL_OK) {
     StringSet *set = new StringSet;
     for (int i = 0; i < argc; i++) {
-      int length;
+      Tcl_Size length;
       const char *str = Tcl_GetStringFromObj(argv[i], &length);
       set->insert(str);
     }
@@ -183,11 +183,11 @@ arcDcalcArgTcl(Tcl_Obj *obj,
 {
   Sta *sta = Sta::sta();
   sta->ensureGraph();
-  int list_argc;
+  Tcl_Size list_argc;
   Tcl_Obj **list_argv;
   if (Tcl_ListObjGetElements(interp, obj, &list_argc, &list_argv) == TCL_OK) {
     const char *input_delay = "0.0";
-    int length;
+    Tcl_Size length;
     if (list_argc == 6)
       input_delay = Tcl_GetStringFromObj(list_argv[5], &length);
     if (list_argc == 5 || list_argc == 6) {


### PR DESCRIPTION
This is the type the Tcl-API provides in its prototypes and starting from Tcl9 this typedef actually changes from `int` to `long`, so will no longer compile when passing an `int*`.

So whenever we get a return value of this type, use the correct typedef to declare the variable. This makes it forward and backward compatible.