### PR TITLE
Provide close2proc function to prevent tcl9 from crashing.

### DIFF
--- a/util/ReportTcl.cc
+++ b/util/ReportTcl.cc
@@ -72,6 +72,11 @@ encapGetHandleProc(ClientData instanceData,
 static int
 encapBlockModeProc(ClientData instanceData, int mode);
 
+static int
+encapClose2Proc(ClientData instanceData,
+                Tcl_Interp *interp,
+                int flags);
+
 #if TCL_MAJOR_VERSION < 9
 static int
 encapCloseProc(ClientData instanceData, Tcl_Interp *interp);
@@ -97,13 +102,13 @@ Tcl_ChannelType tcl_encap_type_stdout = {
 #if TCL_MAJOR_VERSION < 9
   encapSeekProc,
 #else
-  nullptr,  // close2Proc
+  nullptr,  // seekProc unused
 #endif
   encapSetOptionProc,
   encapGetOptionProc,
   encapWatchProc,
   encapGetHandleProc,
-  nullptr,  // close2Proc
+  encapClose2Proc,
   encapBlockModeProc,
   nullptr,  // flushProc
   nullptr,  // handlerProc
@@ -287,6 +292,13 @@ static int
 encapBlockModeProc(ClientData,
                    int)
 {
+  return 0;
+}
+
+static int
+encapClose2Proc(ClientData,
+                Tcl_Interp *,
+                int) {
   return 0;
 }
 


### PR DESCRIPTION
Tcl 9 does not test if the close2Proc function pointer is non-null, but calls it unconditionally:
https://github.com/tcltk/tcl/blob/core-9-0-3/generic/tclIO.c#L384

So we need to provide a non-null function pointer for our code to not crash with Tcl9