### PR TITLE
util/StringUtil.cc: feature-test std::from_chars

### DIFF
--- a/util/StringUtil.cc
+++ b/util/StringUtil.cc
@@ -28,6 +28,7 @@
 #include <cctype>
 #include <charconv>
 #include <system_error>
+#include <version>
 
 namespace sta {
 
@@ -56,12 +57,21 @@ std::pair<float, bool>
 stringFloat(const std::string &str)
 {
   float value;
+#if defined(__cpp_lib_to_chars) && __cpp_lib_to_chars >= 201611L
   auto [ptr, ec] = std::from_chars(str.data(), str.data() + str.size(), value);
   if (ec == std::errc()
       && *ptr == '\0')
     return {value, true};
   else
     return {0.0, false};
+#else
+  char *ptr;
+  value = strtof(str.data(), &ptr);
+  if (!errno || *ptr != '\0')
+    return {0.0, false};
+  else
+    return {value, true};
+#endif
 }
 
 void


### PR DESCRIPTION
Support for std::{from,to}_chars isn't finalized in
libcxx as of the time of writing, see __cpp_lib_to_chars in
https://github.com/llvm/llvm-project/blob/6331bfa41ab529558ec9d645c0effb7a4146591c/libcxx/docs/FeatureTestMacroTable.rst

This patch adds a fallback using strtof. There are two
differences:
* strtof is locale-dependent
* strtof tolerates leading spaces