### PR TITLE
Consider cells with statetable as sequentials

### DIFF
--- a/liberty/Liberty.cc
+++ b/liberty/Liberty.cc
@@ -1489,7 +1489,7 @@ LibertyCell::outputPortSequential(LibertyPort *port)
 bool
 LibertyCell::hasSequentials() const
 {
-  return !sequentials_.empty();
+  return !sequentials_.empty() || statetable_ != nullptr;
 }
 
 void


### PR DESCRIPTION
This change allows MBFFs to be recognized as sequential cells. This may have been inadvertently changed as part of the recent string view changes.

https://github.com/parallaxsw/OpenSTA/commit/67426928762dd68e34a95511a63cf783c673e1c5#diff-c95208684203dca80c7891c815d90ed206d7da59c3da5a55cd26eff9cd43cddcR1491