### PR TITLE
Use fully qualified `::sta::float_inf` - Tcl9 lookup changed.

### DIFF
--- a/search/Search.tcl
+++ b/search/Search.tcl
@@ -485,12 +485,12 @@ proc_redirect report_check_types {
     }
     if { $violators } {
       set group_path_count $sta::group_path_count_max
-      set slack_min [expr -$sta::float_inf]
+      set slack_min [expr -$::sta::float_inf]
       set slack_max 0.0
     } else {
       set group_path_count 1
-      set slack_min [expr -$sta::float_inf]
-      set slack_max $sta::float_inf
+      set slack_min [expr -$::sta::float_inf]
+      set slack_max $::sta::float_inf
     }
 
     set path_ends [find_path_ends "NULL" {} "NULL" 0 \

--- a/util/Util.i
+++ b/util/Util.i
@@ -49,7 +49,7 @@ using namespace sta;
 
 %inline %{
 
-float float_inf = INF;
+const float float_inf = INF;
 
 const char *
 version()


### PR DESCRIPTION
To get the value of a global variable, it seems in Tcl9, this requires to fully qualify it with leading `::`.

While at it, make `float_inf` readonly, as it certainly is not meant to be modified.

Thanks to @mikesinouye for spotting the problem.

Fixes: #422