### PR TITLE
Add missing headers <cstdlib> and <cerrno> to StringUtil.cc

### DIFF
--- a/util/StringUtil.cc
+++ b/util/StringUtil.cc
@@ -26,7 +26,9 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cerrno>
 #include <charconv>
+#include <cstdlib>
 #include <system_error>
 #include <version>
 


### PR DESCRIPTION
Required for `strtof` fallback path.