### PR TITLE
Check is_object before accessing string offset in object_type

### DIFF
--- a/util/Util.i
+++ b/util/Util.i
@@ -252,7 +252,10 @@ is_object(const char *obj)
 const char *
 object_type(const char *obj)
 {
-  return &obj[1 + sizeof(void*) * 2 + 3];
+  if (is_object(obj)) {
+    return &obj[1 + sizeof(void*) * 2 + 3];
+  }
+  return ""; // Return empty string if not a valid object
 }
 
 ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We have fuzz tests that were generating failures on this method.  Since i doubt `object_type` is a performance hot spot it seems worth just making sure the dereference is safe.