### PR TITLE
Expose LevelizeObserver / StaLevelizeObserver + add Sta::setLevelizeObserver

### DIFF
--- a/include/sta/LevelizeObserver.hh
+++ b/include/sta/LevelizeObserver.hh
@@ -1,0 +1,59 @@
+// OpenSTA, Static Timing Analyzer
+// Copyright (c) 2026, Parallax Software, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+// The origin of this software must not be misrepresented; you must not
+// claim that you wrote the original software.
+//
+// Altered source versions must be plainly marked as such, and must not be
+// misrepresented as being the original software.
+//
+// This notice may not be removed or altered from any source distribution.
+
+#pragma once
+
+namespace sta {
+
+class Vertex;
+class Search;
+class GraphDelayCalc;
+
+// Observer fired by Levelize during (re)levelization. Downstream consumers
+// override the two hooks to invalidate caches that depend on vertex levels.
+class LevelizeObserver
+{
+public:
+  virtual ~LevelizeObserver() = default;
+  virtual void levelsChangedBefore() = 0;
+  virtual void levelChangedBefore(Vertex *vertex) = 0;
+};
+
+// Default observer installed by Sta::makeObservers. Forwards level-change
+// events to Search and GraphDelayCalc so their internal caches stay
+// consistent. Subclass and override to extend (call the base methods first,
+// then add your own invalidation).
+class StaLevelizeObserver : public LevelizeObserver
+{
+public:
+  StaLevelizeObserver(Search *search, GraphDelayCalc *graph_delay_calc);
+  void levelsChangedBefore() override;
+  void levelChangedBefore(Vertex *vertex) override;
+
+private:
+  Search *search_;
+  GraphDelayCalc *graph_delay_calc_;
+};
+
+} // namespace sta

--- a/include/sta/Sta.hh
+++ b/include/sta/Sta.hh
@@ -73,6 +73,7 @@ class ClkSkews;
 class ReportField;
 class EquivCells;
 class StaSimObserver;
+class LevelizeObserver;
 class GraphLoop;
 
 using ModeNameMap = std::map<std::string, Mode*, std::less<>>;
@@ -1321,6 +1322,10 @@ public:
   // Ensure a network has been read, linked and liberty libraries exist.
   Network *ensureLibLinked();
   void ensureLevelized();
+  // Replace the Levelize observer. Takes ownership; deletes any prior
+  // observer. Subclass StaLevelizeObserver to extend the default behavior
+  // (Search + GraphDelayCalc forwarding) without re-implementing it.
+  void setLevelizeObserver(LevelizeObserver *observer);
   // Ensure that the timing graph has been built.
   Graph *ensureGraph();
   void ensureClkArrivals();

--- a/search/Levelize.hh
+++ b/search/Levelize.hh
@@ -30,11 +30,11 @@
 
 #include "Graph.hh"
 #include "StaState.hh"
+#include "sta/LevelizeObserver.hh"
 
 namespace sta {
 
 class SearchPred;
-class LevelizeObserver;
 class GraphLoop;
 
 using VertexEdgeIterPair = std::pair<Vertex*,VertexOutEdgeIterator*>;
@@ -131,14 +131,6 @@ public:
 
 private:
   EdgeSeq *edges_;
-};
-
-class LevelizeObserver
-{
-public:
-  virtual ~LevelizeObserver() = default;
-  virtual void levelsChangedBefore() = 0;
-  virtual void levelChangedBefore(Vertex *vertex) = 0;
 };
 
 } // namespace sta

--- a/search/Sta.cc
+++ b/search/Sta.cc
@@ -217,19 +217,6 @@ StaSimObserver::fanoutEdgesChangeAfter(const Pin *pin)
 
 ////////////////////////////////////////////////////////////////
 
-class StaLevelizeObserver : public LevelizeObserver
-{
-public:
-  StaLevelizeObserver(Search *search,
-                      GraphDelayCalc *graph_delay_calc);
-  void levelsChangedBefore() override;
-  void levelChangedBefore(Vertex *vertex) override;
-
-private:
-  Search *search_;
-  GraphDelayCalc *graph_delay_calc_;
-};
-
 StaLevelizeObserver::StaLevelizeObserver(Search *search,
                                          GraphDelayCalc *graph_delay_calc) :
   search_(search),
@@ -3744,6 +3731,12 @@ Sta::ensureLevelized()
 {
   ensureGraph();
   levelize_->ensureLevelized();
+}
+
+void
+Sta::setLevelizeObserver(LevelizeObserver *observer)
+{
+  levelize_->setObserver(observer);
 }
 
 void


### PR DESCRIPTION
 Three small additions to let downstream consumers (OpenROAD's `dbSta`) attach
  their own `LevelizeObserver` without:
  - replicating `StaLevelizeObserver`'s Search + GraphDelayCalc forwarding
    (silent drift risk if this class gains new responsibilities upstream),
  - reaching into the protected `levelize_` member,
  - including the private `search/Levelize.hh` header.

  ## Changes

  1. **New public header `include/sta/LevelizeObserver.hh`** — holds
     `LevelizeObserver` (abstract) and `StaLevelizeObserver` (default impl that
     forwards level-change events to `Search` and `GraphDelayCalc`). Both classes
     moved from their previous private locations.
  2. **`search/Levelize.hh`** — drop the inline `LevelizeObserver` definition;
     include the new public header instead.
  3. **`search/Sta.cc`** — drop the file-local `StaLevelizeObserver` class body;
     keep its method definitions (now defining the public class).
  4. **`include/sta/Sta.hh`** — add public
     `void Sta::setLevelizeObserver(LevelizeObserver *)`.
  5. **`search/Sta.cc`** — implement `Sta::setLevelizeObserver` as a one-line
     forward to `levelize_->setObserver(observer)`.

  No behavior change. `Sta::makeObservers` still installs `StaLevelizeObserver`
  exactly as before.

## Why

  OpenROAD `dbSta` needs to:
  - subclass a `LevelizeObserver` to invalidate its driver-vertex cache when
    levels change, and
  - preserve the existing Search/GraphDelayCalc forwarding that `StaLevelizeObserver`
    provides.

  Today the only way is to:
  - add `${OPENSTA_HOME}` to its private include path (since `search/Levelize.hh`
    isn't public),
  - reach into `Sta::levelize_` directly,
  - copy the body of `StaLevelizeObserver` into a dbSta-local subclass (drift
    risk if upstream ever changes `StaLevelizeObserver`).