### PR TITLE
#436 fixed incorrect bit width calculation

### DIFF
--- a/liberty/LibertyWriter.cc
+++ b/liberty/LibertyWriter.cc
@@ -275,7 +275,7 @@ LibertyWriter::writeBusDcls()
     sta::print(stream_, "  type (\"{}\") {{\n", dcl->name());
     sta::print(stream_, "    base_type : array;\n");
     sta::print(stream_, "    data_type : bit;\n");
-    sta::print(stream_, "    bit_width : {};\n", std::abs(dcl->from() - dcl->to() + 1));
+    sta::print(stream_, "    bit_width : {};\n", std::abs(dcl->from() - dcl->to()) + 1);
     sta::print(stream_, "    bit_from : {};\n", dcl->from());
     sta::print(stream_, "    bit_to : {};\n", dcl->to());
     sta::print(stream_, "  }}\n");


### PR DESCRIPTION
## Issue
writeBusDcls() in liberty/LibertyWriter.cc computes bit_width incorrectly for ascending bus ranges (e.g. [0:10]).

## Root Cause

```cpp
// before — +1 inside abs(), wrong for ascending ranges
std::abs(dcl->from() - dcl->to() + 1)
// ascending  [0:10]:  abs(0  - 10 + 1) = abs(-9) = 9   ← WRONG
// descending [10:0]:  abs(10 - 0  + 1) = 11             ← correct

// after — +1 outside abs(), correct for both
std::abs(dcl->from() - dcl->to()) + 1
// ascending  [0:10]:  abs(0  - 10) + 1 = 11  ✓
// descending [10:0]:  abs(10 - 0)  + 1 = 11  ✓
```

## Change

One character moved — `+1` from inside `std::abs()` to outside.

Tested against OpenSTA 2.5.0.