### PR TITLE
write_verilog: escaped-scalar port reference mismatch

### DIFF
--- a/verilog/VerilogWriter.cc
+++ b/verilog/VerilogWriter.cc
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <map>
+#include <set>
 #include <string>
 #include <string_view>
 
@@ -73,6 +74,7 @@ protected:
                           const Port *port,
                           bool &first_member);
   void writeAssigns(const Instance *inst);
+  std::string netVerilogNameInScope(std::string_view net_name);
 
   int findUnconnectedNetCount(const Instance *inst);
   int findChildNCcount(const Instance *child);
@@ -85,6 +87,7 @@ protected:
   FILE *stream_;
   Network *network_;
   int unconnected_net_index_{1};
+  std::set<std::string, std::less<>> declared_buses_;
 };
 
 void
@@ -172,6 +175,7 @@ VerilogWriter::findHierChildren(const Instance *inst,
 void
 VerilogWriter::writeModule(const Instance *inst)
 {
+  declared_buses_.clear();
   Cell *cell = network_->cell(inst);
   std::string cell_vname = cellVerilogName(std::string(network_->name(cell)));
   sta::print(stream_, "module {} (", cell_vname);
@@ -218,10 +222,12 @@ VerilogWriter::writePortDcls(const Cell *cell)
       const char *vtype = verilogPortDir(dir);
       if (vtype) {
         sta::print(stream_, " {}", vtype);
-        if (network_->isBus(port))
+        if (network_->isBus(port)) {
           sta::print(stream_, " [{}:{}]",
                     network_->fromIndex(port),
                     network_->toIndex(port));
+          declared_buses_.insert(std::string(network_->name(port)));
+        }
         sta::print(stream_, " {};\n", port_vname);
         if (dir->isTristate()) {
           sta::print(stream_, " tri");
@@ -302,6 +308,7 @@ VerilogWriter::writeWireDcls(const Instance *inst)
                range.first,
                range.second,
                net_vname);
+    declared_buses_.insert(bus_name);
   }
 
   // Wire net dcls for writeInstBusPinBit.
@@ -358,6 +365,18 @@ VerilogWriter::writeChild(const Instance *child)
   }
 }
 
+std::string
+VerilogWriter::netVerilogNameInScope(std::string_view net_name)
+{
+  bool is_bus;
+  std::string bus_name;
+  int index;
+  parseBusName(net_name, '[', ']', '\\', is_bus, bus_name, index);
+  if (is_bus && declared_buses_.contains(bus_name))
+    return netVerilogName(net_name);
+  return portVerilogName(net_name);
+}
+
 void
 VerilogWriter::writeInstPin(const Instance *inst,
                             const Port *port,
@@ -368,7 +387,7 @@ VerilogWriter::writeInstPin(const Instance *inst,
     Net *net = network_->net(pin);
     if (net) {
       std::string net_name = network_->name(net);
-      std::string net_vname = netVerilogName(std::string(net_name));
+      std::string net_vname = netVerilogNameInScope(net_name);
       if (!first_port)
         sta::print(stream_, ",\n    ");
       std::string port_vname = portVerilogName(std::string(network_->name(port)));
@@ -427,7 +446,7 @@ VerilogWriter::writeInstBusPinBit(const Instance *inst,
     // There is no verilog syntax to "skip" a bit in the concatentation.
     : sta::format("_NC{}", unconnected_net_index_++);
 
-  std::string net_vname = netVerilogName(net_name);
+  std::string net_vname = netVerilogNameInScope(net_name);
   if (!first_member)
     sta::print(stream_, ",\n    ");
   sta::print(stream_, "{}", net_vname);
@@ -455,8 +474,8 @@ VerilogWriter::writeAssigns(const Instance *inst)
               || (include_pwr_gnd_ && network_->direction(port)->isPowerGround()))
           && network_->name(port) != network_->name(net)) {
         // Port name is different from net name.
-        std::string port_vname = netVerilogName(std::string(network_->name(port)));
-        std::string net_vname = netVerilogName(std::string(network_->name(net)));
+        std::string port_vname = netVerilogNameInScope(network_->name(port));
+        std::string net_vname = netVerilogNameInScope(network_->name(net));
         sta::print(stream_, " assign {} = {};\n",
                    port_vname,
                    net_vname);


### PR DESCRIPTION
For per-bit escaped-scalar ports (single-bit ports whose internal name contains brackets, with no aggregating bus dcl) — e.g. the output of OpenROAD partition-synth + repair_design — `write_verilog` emits dcl/reference forms that don't match:

- `writePortDcls` / `writeWireDcls` route through `portVerilogName` → `\foo[7] ` (escaped scalar).
- `writeInstPin` / `writeInstBusPinBit` / `writeAssigns` route through `netVerilogName` → `foo[7]` (bus-select on undeclared `foo`).

Verilator rejects the resulting netlist:

```
%Error: out.v:198120:65: Illegal bit or array select;
        type does not have a bit range, or bad dimension: data type is 'logic'
```

Track bus prefixes whose dcl is actually emitted in the current module; use `netVerilogName` (bus-select) only when a matching bus dcl exists, otherwise fall back to `portVerilogName` (escaped scalar). Cleared per `writeModule`.

The existing `verilog/test/verilog_escaped_write_*` regressions use proper bus wires/ports, so `declared_buses_` matches and they emit unchanged.