### PR TITLE
Dont spin main for queue

### DIFF
--- a/include/sta/DispatchQueue.hh
+++ b/include/sta/DispatchQueue.hh
@@ -1,11 +1,7 @@
-// Author Phillip Johnston
-// Licensed under CC0 1.0 Universal
-// https://github.com/embeddedartistry/embedded-resources/blob/master/examples/cpp/dispatch.cpp
-// https://embeddedartistry.com/blog/2017/2/1/dispatch-queues?rq=dispatch
-
 #pragma once
 
 #include <atomic>
+#include <cstddef>
 #include <condition_variable>
 #include <cstdint>
 #include <functional>
@@ -15,6 +11,40 @@
 #include <vector>
 
 namespace sta {
+
+class DynamicLatch {
+public:
+  explicit DynamicLatch(std::ptrdiff_t initial_count = 0) 
+    : count_(initial_count) {}
+
+  // Delete copy/move constructors to prevent accidental slicing/copying of atomics
+  DynamicLatch(const DynamicLatch&) = delete;
+  DynamicLatch& operator=(const DynamicLatch&) = delete;
+
+  // Increases the latch count (used when a new task is dispatched)
+  void countUp() {
+    count_.fetch_add(1, std::memory_order_release);
+  }
+
+  // Decreases the latch count and wakes waiting threads if it hits zero
+  void countDown(std::ptrdiff_t n = 1) {
+    if (count_.fetch_sub(n, std::memory_order_release) == n) {
+      count_.notify_all();
+    }
+  }
+
+  // Blocks until the count reaches zero
+  void wait() const {
+    std::ptrdiff_t current = count_.load(std::memory_order_acquire);
+    while (current != 0) {
+      count_.wait(current, std::memory_order_acquire);
+      current = count_.load(std::memory_order_acquire);
+    }
+  }
+
+private:
+  mutable std::atomic<std::ptrdiff_t> count_{0};
+};
 
 class DispatchQueue
 {
@@ -45,7 +75,7 @@ private:
   std::vector<std::thread> threads_;
   std::queue<fp_t> q_;
   std::condition_variable cv_;
-  std::atomic<size_t> pending_task_count_;
+  DynamicLatch pending_task_count_latch_;
   bool quit_ = false;
 };
 

--- a/include/sta/DispatchQueue.hh
+++ b/include/sta/DispatchQueue.hh
@@ -1,3 +1,10 @@
+// Original Author: Phillip Johnston
+// Licensed under CC0 1.0 Universal
+// Original source: https://github.com/embeddedartistry/embedded-resources/blob/master/examples/cpp/dispatch.cpp
+// Original article: https://embeddedartistry.com/blog/2017/2/1/dispatch-queues?rq=dispatch
+//
+// Modified for OpenSTA to use C++20 non-spinning DynamicLatch for synchronization.
+
 #pragma once
 
 #include <atomic>

--- a/include/sta/DispatchQueue.hh
+++ b/include/sta/DispatchQueue.hh
@@ -12,29 +12,38 @@
 
 namespace sta {
 
-class DynamicLatch {
+class DynamicLatch
+{
 public:
-  explicit DynamicLatch(std::ptrdiff_t initial_count = 0) 
-    : count_(initial_count) {}
+  explicit DynamicLatch(std::ptrdiff_t initial_count = 0) :
+    count_(initial_count)
+  {
+  }
 
   // Delete copy/move constructors to prevent accidental slicing/copying of atomics
   DynamicLatch(const DynamicLatch&) = delete;
   DynamicLatch& operator=(const DynamicLatch&) = delete;
 
   // Increases the latch count (used when a new task is dispatched)
-  void countUp() {
+  void
+  countUp()
+  {
     count_.fetch_add(1, std::memory_order_release);
   }
 
   // Decreases the latch count and wakes waiting threads if it hits zero
-  void countDown(std::ptrdiff_t n = 1) {
+  void
+  countDown(std::ptrdiff_t n = 1)
+  {
     if (count_.fetch_sub(n, std::memory_order_release) == n) {
       count_.notify_all();
     }
   }
 
   // Blocks until the count reaches zero
-  void wait() const {
+  void
+  wait() const
+  {
     std::ptrdiff_t current = count_.load(std::memory_order_acquire);
     while (current != 0) {
       count_.wait(current, std::memory_order_acquire);

--- a/util/DispatchQueue.cc
+++ b/util/DispatchQueue.cc
@@ -1,7 +1,9 @@
-// Author Phillip Johnston
+// Original Author: Phillip Johnston
 // Licensed under CC0 1.0 Universal
-// https://github.com/embeddedartistry/embedded-resources/blob/master/examples/cpp/dispatch.cpp
-// https://embeddedartistry.com/blog/2017/2/1/dispatch-queues?rq=dispatch
+// Original source: https://github.com/embeddedartistry/embedded-resources/blob/master/examples/cpp/dispatch.cpp
+// Original article: https://embeddedartistry.com/blog/2017/2/1/dispatch-queues?rq=dispatch
+//
+// Modified for OpenSTA to use C++20 non-spinning DynamicLatch for synchronization.
 
 #include "DispatchQueue.hh"
 

--- a/util/DispatchQueue.cc
+++ b/util/DispatchQueue.cc
@@ -8,8 +8,7 @@
 namespace sta {
 
 DispatchQueue::DispatchQueue(size_t thread_count) :
-  threads_(thread_count),
-  pending_task_count_(0)
+  threads_(thread_count)
 {
   for(size_t i = 0; i < thread_count; i++)
     threads_[i] = std::thread(&DispatchQueue::dispatch_thread_handler, this, i);
@@ -58,8 +57,7 @@ DispatchQueue::getThreadCount() const
 void
 DispatchQueue::finishTasks()
 {
-  while (pending_task_count_.load(std::memory_order_acquire) != 0)
-    std::this_thread::yield();
+  pending_task_count_latch_.wait();
 }
 
 void
@@ -67,7 +65,7 @@ DispatchQueue::dispatch(const fp_t& op)
 {
   std::unique_lock<std::mutex> lock(lock_);
   q_.push(op);
-  pending_task_count_++;
+  pending_task_count_latch_.countUp();
 
   // Manual unlocking is done before notifying, to avoid waking up
   // the waiting thread only to block again (see notify_one for details)
@@ -80,7 +78,7 @@ DispatchQueue::dispatch(fp_t&& op)
 {
   std::unique_lock<std::mutex> lock(lock_);
   q_.push(std::move(op));
-  pending_task_count_++;
+  pending_task_count_latch_.countUp();
 
   // Manual unlocking is done before notifying, to avoid waking up
   // the waiting thread only to block again (see notify_one for details)
@@ -106,7 +104,7 @@ DispatchQueue::dispatch_thread_handler(size_t i)
 
       op(i);
 
-      pending_task_count_--;
+      pending_task_count_latch_.countDown();
       lock.lock();
     }
   } while (!quit_);


### PR DESCRIPTION
Replace the busy-yielding pending_task_count_ loop in DispatchQueue::finishTasks with a blocking DynamicLatch. This avoids having the main thread consume CPU cycles while waiting for dispatched tasks to complete.

The DynamicLatch implementation uses C++20 std::atomic::wait/notify_all for efficient blocking and wakeup.  It functions like [std::latch](https://en.cppreference.com/cpp/thread/latch) except you can also count up with it. 