### PR TITLE
Skip CRPR machinery when no clock is propagated (complete fb5d87bd)

### DIFF
--- a/include/sta/Sdc.hh
+++ b/include/sta/Sdc.hh
@@ -409,6 +409,8 @@ public:
   void setPropagatedClock(Pin *pin);
   void removePropagatedClock(Pin *pin);
   bool isPropagatedClock(const Pin *pin) const;
+  // True if any clock or clock pin is propagated. CRPR is inert otherwise.
+  bool hasPropagatedClock() const;
   void setClockSlew(Clock *clk,
                     const RiseFallBoth *rf,
                     const MinMaxAll *min_max,
@@ -1306,6 +1308,8 @@ protected:
   ClkHpinDisables clk_hpin_disables_;
   bool clk_hpin_disables_valid_;
   PinSet propagated_clk_pins_;
+  mutable bool has_propagated_clk_{false};
+  mutable bool has_propagated_clk_valid_{false};
   ClockLatencies clk_latencies_;
   PinSet clk_latency_pins_;
   EdgeClockLatencyMap edge_clk_latency_map_;

--- a/sdc/Sdc.cc
+++ b/sdc/Sdc.cc
@@ -167,6 +167,7 @@ Sdc::clear()
 {
   deleteConstraints();
   propagated_clk_pins_.clear();
+  has_propagated_clk_valid_ = false;
   clocks_.clear();
   clock_name_map_.clear();
   clock_pin_map_.clear();
@@ -976,6 +977,7 @@ Sdc::makeClock(std::string_view name,
     clk = new Clock(name, clk_index_++, network_);
     clk->setIsPropagated(variables_->propagateAllClocks());
     clocks_.push_back(clk);
+    has_propagated_clk_valid_ = false;
     // Use the copied name in the map.
     clock_name_map_[clk->name()] = clk;
   }
@@ -1010,6 +1012,7 @@ Sdc::makeGeneratedClock(std::string_view name,
   else {
     clk = new Clock(name, clk_index_++, network_);
     clocks_.push_back(clk);
+    has_propagated_clk_valid_ = false;
     clock_name_map_[clk->name()] = clk;
   }
   clk->initGeneratedClk(pins, add_to_pins, src_pin, master_clk,
@@ -1134,6 +1137,7 @@ Sdc::removeClock(Clock *clk)
   deleteClkPinMappings(clk);
   clocks_.erase(std::ranges::find(clocks_, clk));
   clock_name_map_.erase(clk->name());
+  has_propagated_clk_valid_ = false;
   delete clk;
 }
 
@@ -1419,6 +1423,7 @@ void
 Sdc::setPropagatedClock(Clock *clk)
 {
   clk->setIsPropagated(true);
+  has_propagated_clk_valid_ = false;
   removeClockLatency(clk, nullptr);
 }
 
@@ -1426,12 +1431,14 @@ void
 Sdc::removePropagatedClock(Clock *clk)
 {
   clk->setIsPropagated(false);
+  has_propagated_clk_valid_ = false;
 }
 
 void
 Sdc::setPropagatedClock(Pin *pin)
 {
   propagated_clk_pins_.insert(pin);
+  has_propagated_clk_valid_ = false;
   removeClockLatency(nullptr, pin);
 }
 
@@ -1439,12 +1446,31 @@ void
 Sdc::removePropagatedClock(Pin *pin)
 {
   propagated_clk_pins_.erase(pin);
+  has_propagated_clk_valid_ = false;
 }
 
 bool
 Sdc::isPropagatedClock(const Pin *pin) const
 {
   return propagated_clk_pins_.contains(pin);
+}
+
+bool
+Sdc::hasPropagatedClock() const
+{
+  if (!has_propagated_clk_valid_) {
+    has_propagated_clk_ = !propagated_clk_pins_.empty();
+    if (!has_propagated_clk_) {
+      for (const Clock *clk : clocks_) {
+        if (clk->isPropagated()) {
+          has_propagated_clk_ = true;
+          break;
+        }
+      }
+    }
+    has_propagated_clk_valid_ = true;
+  }
+  return has_propagated_clk_;
 }
 
 void

--- a/search/StaState.cc
+++ b/search/StaState.cc
@@ -114,7 +114,10 @@ bool
 StaState::crprActive(const Mode *mode) const
 {
   return mode->sdc()->analysisType() == AnalysisType::ocv
-    && variables_->crprEnabled();
+    && variables_->crprEnabled()
+    // CRPR is inert when no clock is propagated (e.g. pre-CTS): the clock path
+    // common to launch/capture has no delay, so CheckCrpr returns zero anyway.
+    && mode->sdc()->hasPropagatedClock();
 }
 
 bool


### PR DESCRIPTION
## Summary
Make `crprActive()` additionally require that the SDC has at least one propagated clock. With ideal clocks CRPR can produce no correction, so this skips the CRPR search/CheckCrpr machinery entirely in that case.

This completes the intent of fb5d87bd ("no crpr for ideal clocks"): that commit added `TagGroupBldr::hasPropagatedClk()` but only consulted it when skipping `pruneCrprArrivals()`. The gate that actually enables CRPR, `StaState::crprActive()`, still keyed only off `analysisType()==ocv && crprEnabled()`.

## Motivation
In pre-CTS placement-stage timing, OCV is active and `crpr_enabled` is on, but clocks are ideal — propagation is applied after CTS. On high-reconvergence clock structures the CRPR path can consume very large amounts of memory while contributing nothing, since the correction is already zero for ideal clocks. Setting `set_crpr_enabled 0` avoids it, which confirms the cost is pure overhead in this case.

This matters for automated design-space exploration, which runs STA at placement to prune configurations cheaply — including pathological ones that we specifically want to reject *before* paying for CTS and routing. A configuration that blows up CRPR memory at placement can OOM-kill the process and derail the whole sweep, instead of simply being scored and pruned. Skipping the inert CRPR work at placement keeps that early pruning bounded and robust, while full CRPR still applies post-CTS where it has effect.

## Why this is result-neutral
`CheckCrpr::checkCrpr1` / `outputDelayCrpr1` already return 0 when clocks are ideal (`isPropagated()` guards), and `ClkInfo` already stores a null crpr clock path for unpropagated clocks. This change only avoids building machinery to feed a no-op. Once any clock is propagated (post-CTS / sign-off), behavior is unchanged.

## Change
- `Sdc::hasPropagatedClock()` — cached predicate (true if any clock or clock pin is propagated), invalidated on set/remove propagated clock, clock creation, and clock removal.
- `StaState::crprActive()` — additionally require `sdc->hasPropagatedClock()`.

## Validation
- All-ideal-clock pre-CTS report: peak RSS drops to the `set_crpr_enabled 0` level; reported slacks/WNS/TNS unchanged.
- Post-CTS (propagated) report: identical results and memory to before.
- Existing CRPR regressions unchanged.
