### PR TITLE
Add native gzip compression support to write_verilog

### DIFF
--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -169,6 +169,7 @@ record_public_tests {
   verilog_well_supplies
   verilog_specify
   verilog_write_escape
+  verilog_write_gzip
   verilog_unconnected_hpin
 }
 

--- a/test/verilog_write_gzip.ok
+++ b/test/verilog_write_gzip.ok
@@ -1,0 +1,33 @@
+module top (in1,
+    in2,
+    clk1,
+    clk2,
+    clk3,
+    out);
+ input in1;
+ input in2;
+ input clk1;
+ input clk2;
+ input clk3;
+ output out;
+
+ wire r1q;
+ wire r2q;
+ wire u1z;
+ wire u2z;
+
+ DFFHQx4_ASAP7_75t_R r1 (.Q(r1q),
+    .CLK(clk1),
+    .D(in1));
+ DFFHQx4_ASAP7_75t_R r2 (.Q(r2q),
+    .CLK(clk2),
+    .D(in2));
+ DFFHQx4_ASAP7_75t_R r3 (.Q(out),
+    .CLK(clk3),
+    .D(u2z));
+ BUFx2_ASAP7_75t_R u1 (.Y(u1z),
+    .A(r2q));
+ AND2x2_ASAP7_75t_R u2 (.Y(u2z),
+    .A(r1q),
+    .B(u1z));
+endmodule

--- a/test/verilog_write_gzip.tcl
+++ b/test/verilog_write_gzip.tcl
@@ -1,0 +1,8 @@
+# Check that write_verilog supports gzip compression natively if .gz extension is provided.
+source helpers.tcl
+read_liberty asap7_small.lib.gz
+read_verilog reg1_asap7.v
+link_design top
+set verilog_file [make_result_file "verilog_write_gzip.v.gz"]
+write_verilog $verilog_file
+report_file $verilog_file

--- a/verilog/VerilogWriter.cc
+++ b/verilog/VerilogWriter.cc
@@ -33,6 +33,7 @@
 #include "Error.hh"
 #include "Format.hh"
 #include "Liberty.hh"
+#include "Zlib.hh"
 #include "Network.hh"
 #include "NetworkCmp.hh"
 #include "ParseBus.hh"
@@ -47,7 +48,7 @@ public:
   VerilogWriter(const char *filename,
                 bool include_pwr_gnd,
                 CellSeq *remove_cells,
-                FILE *stream,
+                gzFile stream,
                 Network *network);
   void writeModules();
 
@@ -82,7 +83,7 @@ protected:
   const char *filename_;
   bool include_pwr_gnd_;
   CellSet remove_cells_;
-  FILE *stream_;
+  gzFile stream_;
   Network *network_;
   int unconnected_net_index_{1};
 };
@@ -94,12 +95,13 @@ writeVerilog(const char *filename,
              Network *network)
 {
   if (network->topInstance()) {
-    FILE *stream = fopen(filename, "w");
+    bool gzip = std::string_view(filename).ends_with(".gz");
+    gzFile stream = gzopen(filename, gzip ? "wb" : "wT");
     if (stream) {
       VerilogWriter writer(filename, include_pwr_gnd,
                            remove_cells, stream, network);
       writer.writeModules();
-      fclose(stream);
+      gzclose(stream);
     }
     else
       throw FileNotWritable(filename);
@@ -109,7 +111,7 @@ writeVerilog(const char *filename,
 VerilogWriter::VerilogWriter(const char *filename,
                              bool include_pwr_gnd,
                              CellSeq *remove_cells,
-                             FILE *stream,
+                             gzFile stream,
                              Network *network) :
   filename_(filename),
   include_pwr_gnd_(include_pwr_gnd),


### PR DESCRIPTION
Have `write_verilog` detect if the user requested `.gz` and if so automatically write a gzipped file.