### PR TITLE
docs: remove duplicate SSTA report field

### DIFF
--- a/doc/ChangeLog.txt
+++ b/doc/ChangeLog.txt
@@ -55,7 +55,7 @@ link_design top
 create_clock -period 50 clk
 set_input_delay -clock clk 1 {in1 in2}
 set sta_pocv_mode skew_normal
-report_checks -fields {slew variation input_pin variation} -digits 3
+report_checks -fields {slew variation input_pin} -digits 3
 
 Startpoint: r2 (rising edge-triggered flip-flop clocked by clk)
 Endpoint: r3 (rising edge-triggered flip-flop clocked by clk)


### PR DESCRIPTION
Summary:
- remove the duplicate `variation` field from the SSTA `report_checks` example in `doc/ChangeLog.txt`
- keep the release-note example aligned with the same example in `doc/OpenSTA.fodt` and the `report_checks -fields` option list in `search/Search.tcl`

Validation:
- `rg -n 'fields \\{slew variation input_pin variation\\}|fields \\{slew variation input_pin\\}|capacitance\\|slew\\|fanout\\|input_pin\\|net\\|src_attr\\|variation' doc/ChangeLog.txt doc/OpenSTA.fodt search/Search.tcl`\n- `git diff --check`\n\nI checked issue #446 and only this duplicate-field bullet still reproduced in the current source tree; the spelling items described there appear already corrected in `doc/OpenSTA.fodt`.