### PR TITLE
Add property-based -filter to get_scenes / get_modes, and make Scene/Mode properties extensible

### DIFF
--- a/include/sta/FilterObjects.hh
+++ b/include/sta/FilterObjects.hh
@@ -30,6 +30,7 @@
 
 #include "GraphClass.hh"
 #include "NetworkClass.hh"
+#include "Scene.hh"
 #include "SdcClass.hh"
 #include "SearchClass.hh"
 #include "StringUtil.hh"
@@ -63,6 +64,16 @@ ClockSeq
 filterClocks(std::string_view filter_expression,
              ClockSeq *clks,
              Sta *sta);
+
+SceneSeq
+filterScenes(std::string_view filter_expression,
+             SceneSeq *scenes,
+             Sta *sta);
+
+ModeSeq
+filterModes(std::string_view filter_expression,
+            ModeSeq *modes,
+            Sta *sta);
 
 LibertyCellSeq
 filterLibCells(std::string_view filter_expression,

--- a/include/sta/Property.hh
+++ b/include/sta/Property.hh
@@ -124,6 +124,10 @@ public:
                       const PropertyRegistry<const Net *>::PropertyHandler &handler);
   void defineProperty(std::string_view property,
                       const PropertyRegistry<const Clock *>::PropertyHandler &handler);
+  void defineProperty(std::string_view property,
+                      const PropertyRegistry<const Scene *>::PropertyHandler &handler);
+  void defineProperty(std::string_view property,
+                      const PropertyRegistry<const Mode *>::PropertyHandler &handler);
 
 protected:
   PropertyValue portSlew(const Port *port,
@@ -160,6 +164,8 @@ protected:
   PropertyRegistry<const Pin*> registry_pin_;
   PropertyRegistry<const Net*> registry_net_;
   PropertyRegistry<const Clock*> registry_clock_;
+  PropertyRegistry<const Scene*> registry_scene_;
+  PropertyRegistry<const Mode*> registry_mode_;
 
   Sta *sta_;
 };

--- a/include/sta/Property.hh
+++ b/include/sta/Property.hh
@@ -159,6 +159,22 @@ private:
   const Unit *unit_;
 };
 
+// Key for user-defined property values: the object instance (nullptr for
+// the property's type default), its object type name and the property name.
+class UserPropertyKey
+{
+public:
+  UserPropertyKey(const void *object,
+                  std::string_view object_type,
+                  std::string_view property);
+  bool operator<(const UserPropertyKey &key) const;
+
+private:
+  const void *object_;
+  std::string object_type_;
+  std::string property_;
+};
+
 class Properties
 {
 public:
@@ -227,19 +243,17 @@ public:
   void defineProperty(std::string_view property,
                       const PropertyRegistry<const Mode *>::PropertyHandler &handler);
 
-  // User-defined, per-object mutable properties. defineSceneProperty registers
-  // a scene property of the given type ("bool", "float" or "string") with a
-  // typed default; setSceneProperty overrides the value on one scene. The
+  // User-defined, per-object mutable properties. defineUserProperty registers
+  // a property of the given value type ("bool", "float" or "string") with a
+  // typed default; setUserProperty overrides the value on one object. The
   // property is read through the same registry path as every other property so
-  // get_property / get_scenes -filter work unchanged.
-  void defineSceneProperty(std::string_view property,
-                           std::string_view type);
-  void setSceneProperty(const Scene *scene,
-                        std::string_view property,
-                        std::string_view value);
-  void defineModeProperty(std::string_view property,
-                          std::string_view type);
-  void setModeProperty(const Mode *mode,
+  // get_property / get_* -filter work unchanged.
+  template<class TYPE>
+  void defineUserProperty(std::string_view object_type,
+                          std::string_view property,
+                          std::string_view value_type);
+  void setUserProperty(const void *object,
+                       std::string_view object_type,
                        std::string_view property,
                        std::string_view value);
 
@@ -284,11 +298,9 @@ protected:
   PropertyRegistry<const Scene*> registry_scene_;
   PropertyRegistry<const Mode*> registry_mode_;
 
-  // User-defined property values, keyed by object then property name.
-  std::map<const Scene*, std::map<std::string, PropertyValue, std::less<>>> scene_user_props_;
-  std::map<std::string, PropertyValue, std::less<>> scene_user_prop_defaults_;
-  std::map<const Mode*, std::map<std::string, PropertyValue, std::less<>>> mode_user_props_;
-  std::map<std::string, PropertyValue, std::less<>> mode_user_prop_defaults_;
+  // User-defined property values for all object types; type defaults seeded
+  // by defineUserProperty are stored with a null object.
+  std::map<UserPropertyKey, PropertyValue> user_prop_values_;
 
   Sta *sta_;
 };

--- a/include/sta/Property.hh
+++ b/include/sta/Property.hh
@@ -28,6 +28,7 @@
 #include <map>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include "LibertyClass.hh"
 #include "NetworkClass.hh"
@@ -159,19 +160,17 @@ private:
   const Unit *unit_;
 };
 
-// Key for user-defined property values: the object instance (nullptr for
-// the property's type record), its object type name and the property name.
+// Key for user-defined property values: the object instance and the
+// property name.
 class PropertyKey
 {
 public:
   PropertyKey(const void *object,
-              std::string_view object_type,
               std::string_view property);
   bool operator<(const PropertyKey &key) const;
 
 private:
   const void *object_;
-  std::string object_type_;
   std::string property_;
 };
 
@@ -282,7 +281,7 @@ protected:
   PropertyValue edgeDelay(Edge *edge,
                           const RiseFall *rf,
                           const MinMax *min_max);
-  PropertyValue propertyTypeValue(std::string_view type);
+  PropertyValue::Type propertyType(std::string_view type);
   PropertyValue coercePropertyValue(PropertyValue::Type type,
                                     std::string_view value);
 
@@ -299,8 +298,10 @@ protected:
   PropertyRegistry<const Scene*> registry_scene_;
   PropertyRegistry<const Mode*> registry_mode_;
 
-  // User-defined property values for all object types; the type record
-  // seeded by defineProperty is stored with a null object.
+  // Value types of user-defined properties keyed by object type name and
+  // property name.
+  std::map<std::pair<std::string, std::string>, PropertyValue::Type> prop_types_;
+  // User-defined property values.
   std::map<PropertyKey, PropertyValue> prop_values_;
 
   Sta *sta_;

--- a/include/sta/Property.hh
+++ b/include/sta/Property.hh
@@ -161,13 +161,13 @@ private:
 
 // Key for user-defined property values: the object instance (nullptr for
 // the property's type default), its object type name and the property name.
-class UserPropertyKey
+class PropertyKey
 {
 public:
-  UserPropertyKey(const void *object,
-                  std::string_view object_type,
-                  std::string_view property);
-  bool operator<(const UserPropertyKey &key) const;
+  PropertyKey(const void *object,
+              std::string_view object_type,
+              std::string_view property);
+  bool operator<(const PropertyKey &key) const;
 
 private:
   const void *object_;
@@ -243,19 +243,19 @@ public:
   void defineProperty(std::string_view property,
                       const PropertyRegistry<const Mode *>::PropertyHandler &handler);
 
-  // User-defined, per-object mutable properties. defineUserProperty registers
+  // User-defined, per-object mutable properties. defineProperty registers
   // a property of the given value type ("bool", "float" or "string") with a
-  // typed default; setUserProperty overrides the value on one object. The
+  // typed default; setProperty overrides the value on one object. The
   // property is read through the same registry path as every other property so
   // get_property / get_* -filter work unchanged.
   template<class TYPE>
-  void defineUserProperty(std::string_view object_type,
-                          std::string_view property,
-                          std::string_view value_type);
-  void setUserProperty(const void *object,
-                       std::string_view object_type,
-                       std::string_view property,
-                       std::string_view value);
+  void defineProperty(std::string_view object_type,
+                      std::string_view property,
+                      std::string_view value_type);
+  void setProperty(const void *object,
+                   std::string_view object_type,
+                   std::string_view property,
+                   std::string_view value);
 
 protected:
   PropertyValue portSlew(const Port *port,
@@ -281,9 +281,9 @@ protected:
   PropertyValue edgeDelay(Edge *edge,
                           const RiseFall *rf,
                           const MinMax *min_max);
-  PropertyValue userPropertyDefault(std::string_view type);
-  PropertyValue coerceUserValue(PropertyValue::Type type,
-                                std::string_view value);
+  PropertyValue propertyDefault(std::string_view type);
+  PropertyValue coercePropertyValue(PropertyValue::Type type,
+                                    std::string_view value);
 
   PropertyRegistry<const Library*> registry_library_;
   PropertyRegistry<const LibertyLibrary*> registry_liberty_library_;
@@ -299,8 +299,8 @@ protected:
   PropertyRegistry<const Mode*> registry_mode_;
 
   // User-defined property values for all object types; type defaults seeded
-  // by defineUserProperty are stored with a null object.
-  std::map<UserPropertyKey, PropertyValue> user_prop_values_;
+  // by defineProperty are stored with a null object.
+  std::map<PropertyKey, PropertyValue> prop_values_;
 
   Sta *sta_;
 };

--- a/include/sta/Property.hh
+++ b/include/sta/Property.hh
@@ -160,7 +160,7 @@ private:
 };
 
 // Key for user-defined property values: the object instance (nullptr for
-// the property's type default), its object type name and the property name.
+// the property's type record), its object type name and the property name.
 class PropertyKey
 {
 public:
@@ -244,10 +244,11 @@ public:
                       const PropertyRegistry<const Mode *>::PropertyHandler &handler);
 
   // User-defined, per-object mutable properties. defineProperty registers
-  // a property of the given value type ("bool", "float" or "string") with a
-  // typed default; setProperty overrides the value on one object. The
-  // property is read through the same registry path as every other property so
-  // get_property / get_* -filter work unchanged.
+  // a property of the given value type ("bool", "float" or "string");
+  // setProperty sets the value on one object. Objects the property was never
+  // set on read back as an empty (none) value. The property is read through
+  // the same registry path as every other property so get_property /
+  // get_* -filter work unchanged.
   template<class TYPE>
   void defineProperty(std::string_view object_type,
                       std::string_view property,
@@ -281,7 +282,7 @@ protected:
   PropertyValue edgeDelay(Edge *edge,
                           const RiseFall *rf,
                           const MinMax *min_max);
-  PropertyValue propertyDefault(std::string_view type);
+  PropertyValue propertyTypeValue(std::string_view type);
   PropertyValue coercePropertyValue(PropertyValue::Type type,
                                     std::string_view value);
 
@@ -298,8 +299,8 @@ protected:
   PropertyRegistry<const Scene*> registry_scene_;
   PropertyRegistry<const Mode*> registry_mode_;
 
-  // User-defined property values for all object types; type defaults seeded
-  // by defineProperty are stored with a null object.
+  // User-defined property values for all object types; the type record
+  // seeded by defineProperty is stored with a null object.
   std::map<PropertyKey, PropertyValue> prop_values_;
 
   Sta *sta_;

--- a/include/sta/Property.hh
+++ b/include/sta/Property.hh
@@ -61,115 +61,6 @@ private:
   std::map<std::string, PropertyHandler, std::less<>> registry_;
 };
 
-class Properties
-{
-public:
-  Properties(Sta *sta);
-
-  PropertyValue getProperty(const Library *lib,
-                            std::string_view property);
-  PropertyValue getProperty(const LibertyLibrary *lib,
-                            std::string_view property);
-  PropertyValue getProperty(const Cell *cell,
-                            std::string_view property);
-  PropertyValue getProperty(const LibertyCell *cell,
-                            std::string_view property);
-  PropertyValue getProperty(const Port *port,
-                            std::string_view property);
-  PropertyValue getProperty(const LibertyPort *port,
-                            std::string_view property);
-  PropertyValue getProperty(const Instance *inst,
-                            std::string_view property);
-  PropertyValue getProperty(const Pin *pin,
-                            std::string_view property);
-  PropertyValue getProperty(const Net *net,
-                            std::string_view property);
-  PropertyValue getProperty(Edge *edge,
-                            std::string_view property);
-  PropertyValue getProperty(const Clock *clk,
-                            std::string_view property);
-  PropertyValue getProperty(const Scene *scene,
-                            std::string_view property);
-  PropertyValue getProperty(const Mode *mode,
-                            std::string_view property);
-  PropertyValue getProperty(PathEnd *end,
-                            std::string_view property);
-  PropertyValue getProperty(Path *path,
-                            std::string_view property);
-  PropertyValue getProperty(TimingArcSet *arc_set,
-                            std::string_view property);
-
-  // Define handler for external property.
-  // properties->defineProperty("foo",
-  //                            [] (const Instance *, Sta *) -> PropertyValue {
-  //                              return PropertyValue("bar");
-  //                            });
-  void defineProperty(std::string_view property,
-                      const PropertyRegistry<const Library *>::PropertyHandler &handler);
-  void defineProperty(std::string_view property,
-                      const PropertyRegistry<const LibertyLibrary *>::PropertyHandler &handler);
-  void defineProperty(std::string_view property,
-                      const PropertyRegistry<const Cell *>::PropertyHandler &handler);
-  void defineProperty(std::string_view property,
-                      const PropertyRegistry<const LibertyCell *>::PropertyHandler &handler);
-  void defineProperty(std::string_view property,
-                      const PropertyRegistry<const Port *>::PropertyHandler &handler);
-  void defineProperty(std::string_view property,
-                      const PropertyRegistry<const LibertyPort *>::PropertyHandler &handler);
-  void defineProperty(std::string_view property,
-                      const PropertyRegistry<const Instance *>::PropertyHandler &handler);
-  void defineProperty(std::string_view property,
-                      const PropertyRegistry<const Pin *>::PropertyHandler &handler);
-  void defineProperty(std::string_view property,
-                      const PropertyRegistry<const Net *>::PropertyHandler &handler);
-  void defineProperty(std::string_view property,
-                      const PropertyRegistry<const Clock *>::PropertyHandler &handler);
-  void defineProperty(std::string_view property,
-                      const PropertyRegistry<const Scene *>::PropertyHandler &handler);
-  void defineProperty(std::string_view property,
-                      const PropertyRegistry<const Mode *>::PropertyHandler &handler);
-
-protected:
-  PropertyValue portSlew(const Port *port,
-                         const RiseFallBoth *rf,
-                         const MinMax *min_max);
-  PropertyValue portSlack(const Port *port,
-                          const RiseFallBoth *rf,
-                          const MinMax *min_max);
-  PropertyValue pinArrival(const Pin *pin,
-                           const RiseFallBoth *rf,
-                           const MinMax *min_max);
-
-  PropertyValue pinSlack(const Pin *pin,
-                         const RiseFallBoth *rf,
-                         const MinMax *min_max);
-  PropertyValue pinSlew(const Pin *pin,
-                        const RiseFallBoth *rf,
-                        const MinMax *min_max);
-
-  PropertyValue delayPropertyValue(Delay delay);
-  PropertyValue resistancePropertyValue(float res);
-  PropertyValue capacitancePropertyValue(float cap);
-  PropertyValue edgeDelay(Edge *edge,
-                          const RiseFall *rf,
-                          const MinMax *min_max);
-
-  PropertyRegistry<const Library*> registry_library_;
-  PropertyRegistry<const LibertyLibrary*> registry_liberty_library_;
-  PropertyRegistry<const Cell*> registry_cell_;
-  PropertyRegistry<const LibertyCell*> registry_liberty_cell_;
-  PropertyRegistry<const Port*> registry_port_;
-  PropertyRegistry<const LibertyPort*> registry_liberty_port_;
-  PropertyRegistry<const Instance*> registry_instance_;
-  PropertyRegistry<const Pin*> registry_pin_;
-  PropertyRegistry<const Net*> registry_net_;
-  PropertyRegistry<const Clock*> registry_clock_;
-  PropertyRegistry<const Scene*> registry_scene_;
-  PropertyRegistry<const Mode*> registry_mode_;
-
-  Sta *sta_;
-};
-
 // Adding a new property type
 //  value union (string values use std::string* so the union stays trivial)
 //  enum Type
@@ -266,6 +157,140 @@ private:
     PwrActivity pwr_activity_;
   };
   const Unit *unit_;
+};
+
+class Properties
+{
+public:
+  Properties(Sta *sta);
+
+  PropertyValue getProperty(const Library *lib,
+                            std::string_view property);
+  PropertyValue getProperty(const LibertyLibrary *lib,
+                            std::string_view property);
+  PropertyValue getProperty(const Cell *cell,
+                            std::string_view property);
+  PropertyValue getProperty(const LibertyCell *cell,
+                            std::string_view property);
+  PropertyValue getProperty(const Port *port,
+                            std::string_view property);
+  PropertyValue getProperty(const LibertyPort *port,
+                            std::string_view property);
+  PropertyValue getProperty(const Instance *inst,
+                            std::string_view property);
+  PropertyValue getProperty(const Pin *pin,
+                            std::string_view property);
+  PropertyValue getProperty(const Net *net,
+                            std::string_view property);
+  PropertyValue getProperty(Edge *edge,
+                            std::string_view property);
+  PropertyValue getProperty(const Clock *clk,
+                            std::string_view property);
+  PropertyValue getProperty(const Scene *scene,
+                            std::string_view property);
+  PropertyValue getProperty(const Mode *mode,
+                            std::string_view property);
+  PropertyValue getProperty(PathEnd *end,
+                            std::string_view property);
+  PropertyValue getProperty(Path *path,
+                            std::string_view property);
+  PropertyValue getProperty(TimingArcSet *arc_set,
+                            std::string_view property);
+
+  // Define handler for external property.
+  // properties->defineProperty("foo",
+  //                            [] (const Instance *, Sta *) -> PropertyValue {
+  //                              return PropertyValue("bar");
+  //                            });
+  void defineProperty(std::string_view property,
+                      const PropertyRegistry<const Library *>::PropertyHandler &handler);
+  void defineProperty(std::string_view property,
+                      const PropertyRegistry<const LibertyLibrary *>::PropertyHandler &handler);
+  void defineProperty(std::string_view property,
+                      const PropertyRegistry<const Cell *>::PropertyHandler &handler);
+  void defineProperty(std::string_view property,
+                      const PropertyRegistry<const LibertyCell *>::PropertyHandler &handler);
+  void defineProperty(std::string_view property,
+                      const PropertyRegistry<const Port *>::PropertyHandler &handler);
+  void defineProperty(std::string_view property,
+                      const PropertyRegistry<const LibertyPort *>::PropertyHandler &handler);
+  void defineProperty(std::string_view property,
+                      const PropertyRegistry<const Instance *>::PropertyHandler &handler);
+  void defineProperty(std::string_view property,
+                      const PropertyRegistry<const Pin *>::PropertyHandler &handler);
+  void defineProperty(std::string_view property,
+                      const PropertyRegistry<const Net *>::PropertyHandler &handler);
+  void defineProperty(std::string_view property,
+                      const PropertyRegistry<const Clock *>::PropertyHandler &handler);
+  void defineProperty(std::string_view property,
+                      const PropertyRegistry<const Scene *>::PropertyHandler &handler);
+  void defineProperty(std::string_view property,
+                      const PropertyRegistry<const Mode *>::PropertyHandler &handler);
+
+  // User-defined, per-object mutable properties. defineSceneProperty registers
+  // a scene property of the given type ("bool", "float" or "string") with a
+  // typed default; setSceneProperty overrides the value on one scene. The
+  // property is read through the same registry path as every other property so
+  // get_property / get_scenes -filter work unchanged.
+  void defineSceneProperty(std::string_view property,
+                           std::string_view type);
+  void setSceneProperty(const Scene *scene,
+                        std::string_view property,
+                        std::string_view value);
+  void defineModeProperty(std::string_view property,
+                          std::string_view type);
+  void setModeProperty(const Mode *mode,
+                       std::string_view property,
+                       std::string_view value);
+
+protected:
+  PropertyValue portSlew(const Port *port,
+                         const RiseFallBoth *rf,
+                         const MinMax *min_max);
+  PropertyValue portSlack(const Port *port,
+                          const RiseFallBoth *rf,
+                          const MinMax *min_max);
+  PropertyValue pinArrival(const Pin *pin,
+                           const RiseFallBoth *rf,
+                           const MinMax *min_max);
+
+  PropertyValue pinSlack(const Pin *pin,
+                         const RiseFallBoth *rf,
+                         const MinMax *min_max);
+  PropertyValue pinSlew(const Pin *pin,
+                        const RiseFallBoth *rf,
+                        const MinMax *min_max);
+
+  PropertyValue delayPropertyValue(Delay delay);
+  PropertyValue resistancePropertyValue(float res);
+  PropertyValue capacitancePropertyValue(float cap);
+  PropertyValue edgeDelay(Edge *edge,
+                          const RiseFall *rf,
+                          const MinMax *min_max);
+  PropertyValue userPropertyDefault(std::string_view type);
+  PropertyValue coerceUserValue(PropertyValue::Type type,
+                                std::string_view value);
+
+  PropertyRegistry<const Library*> registry_library_;
+  PropertyRegistry<const LibertyLibrary*> registry_liberty_library_;
+  PropertyRegistry<const Cell*> registry_cell_;
+  PropertyRegistry<const LibertyCell*> registry_liberty_cell_;
+  PropertyRegistry<const Port*> registry_port_;
+  PropertyRegistry<const LibertyPort*> registry_liberty_port_;
+  PropertyRegistry<const Instance*> registry_instance_;
+  PropertyRegistry<const Pin*> registry_pin_;
+  PropertyRegistry<const Net*> registry_net_;
+  PropertyRegistry<const Clock*> registry_clock_;
+  PropertyRegistry<const Scene*> registry_scene_;
+  PropertyRegistry<const Mode*> registry_mode_;
+
+  // User-defined property values, keyed by object then property name.
+  std::map<const Scene*, std::map<std::string, PropertyValue, std::less<>>> scene_user_props_;
+  std::map<std::string, PropertyValue, std::less<>> scene_user_prop_defaults_;
+  std::map<const Mode*, std::map<std::string, PropertyValue, std::less<>>> mode_user_props_;
+  std::map<std::string, PropertyValue, std::less<>> mode_user_prop_defaults_;
+
+  Sta *sta_;
 };
 
 } // namespace sta

--- a/sdc/FilterObjects.cc
+++ b/sdc/FilterObjects.cc
@@ -42,6 +42,7 @@
 #include "GraphCmp.hh"
 #include "Liberty.hh"
 #include "LibertyClass.hh"
+#include "Mode.hh"
 #include "Network.hh"
 #include "NetworkClass.hh"
 #include "PathEnd.hh"
@@ -495,6 +496,30 @@ filterClocks(std::string_view filter_expression,
                                        const Clock *clk2) {
                                      return clk1->name() < clk2->name();
                                    }, sta);
+}
+
+SceneSeq
+filterScenes(std::string_view filter_expression,
+             SceneSeq *scenes,
+             Sta *sta)
+{
+  return filterObjects<Scene>(filter_expression, scenes,
+                              [] (const Scene *scene1,
+                                  const Scene *scene2) {
+                                return scene1->name() < scene2->name();
+                              }, sta);
+}
+
+ModeSeq
+filterModes(std::string_view filter_expression,
+            ModeSeq *modes,
+            Sta *sta)
+{
+  return filterObjects<Mode>(filter_expression, modes,
+                             [] (const Mode *mode1,
+                                 const Mode *mode2) {
+                               return mode1->name() < mode2->name();
+                             }, sta);
 }
 
 LibertyCellSeq

--- a/sdc/Sdc.i
+++ b/sdc/Sdc.i
@@ -1531,6 +1531,22 @@ filter_clocks(const char *filter_expression,
   return filterClocks(filter_expression, clocks, sta);
 }
 
+SceneSeq
+filter_scenes(const char *filter_expression,
+              SceneSeq *scenes)
+{
+  sta::Sta *sta = Sta::sta();
+  return filterScenes(filter_expression, scenes, sta);
+}
+
+ModeSeq
+filter_modes(const char *filter_expression,
+             ModeSeq *modes)
+{
+  sta::Sta *sta = Sta::sta();
+  return filterModes(filter_expression, modes, sta);
+}
+
 LibertyCellSeq
 filter_lib_cells(const char *filter_expression,
                  LibertyCellSeq *cells)

--- a/search/Property.cc
+++ b/search/Property.cc
@@ -1388,6 +1388,101 @@ Properties::defineProperty(std::string_view property,
 
 ////////////////////////////////////////////////////////////////
 
+PropertyValue
+Properties::userPropertyDefault(std::string_view type)
+{
+  if (type == "bool" || type == "boolean")
+    return PropertyValue(false);
+  else if (type == "float" || type == "double" || type == "number")
+    return PropertyValue(0.0f, sta_->units()->scalarUnit());
+  else if (type == "string")
+    return PropertyValue(std::string());
+  else
+    sta_->report()->error(2210, "unknown property type '{}' (use bool, float or string).",
+                          type);
+  return PropertyValue();
+}
+
+PropertyValue
+Properties::coerceUserValue(PropertyValue::Type type,
+                            std::string_view value)
+{
+  switch (type) {
+  case PropertyValue::Type::bool_:
+    return PropertyValue(value == "true" || value == "1");
+  case PropertyValue::Type::float_: {
+    auto [number, valid] = stringFloat(std::string(value));
+    return PropertyValue(valid ? number : 0.0f, sta_->units()->scalarUnit());
+  }
+  default:
+    return PropertyValue(std::string(value));
+  }
+}
+
+void
+Properties::defineSceneProperty(std::string_view property,
+                                std::string_view type)
+{
+  std::string name(property);
+  scene_user_prop_defaults_[name] = userPropertyDefault(type);
+  defineProperty(property,
+                 [this, name] (const Scene *scene, Sta *) -> PropertyValue {
+    auto oi = scene_user_props_.find(scene);
+    if (oi != scene_user_props_.end()) {
+      auto pi = oi->second.find(name);
+      if (pi != oi->second.end())
+        return pi->second;
+    }
+    // Unset on this scene: fall back to the type default seeded by define.
+    return scene_user_prop_defaults_.at(name);
+  });
+}
+
+void
+Properties::setSceneProperty(const Scene *scene,
+                             std::string_view property,
+                             std::string_view value)
+{
+  auto di = scene_user_prop_defaults_.find(property);
+  if (di == scene_user_prop_defaults_.end())
+    sta_->report()->error(2211, "scene property '{}' is not defined.", property);
+  scene_user_props_[scene][std::string(property)] =
+    coerceUserValue(di->second.type(), value);
+}
+
+void
+Properties::defineModeProperty(std::string_view property,
+                               std::string_view type)
+{
+  std::string name(property);
+  mode_user_prop_defaults_[name] = userPropertyDefault(type);
+  defineProperty(property,
+                 [this, name] (const Mode *mode, Sta *) -> PropertyValue {
+    auto oi = mode_user_props_.find(mode);
+    if (oi != mode_user_props_.end()) {
+      auto pi = oi->second.find(name);
+      if (pi != oi->second.end())
+        return pi->second;
+    }
+    // Unset on this mode: fall back to the type default seeded by define.
+    return mode_user_prop_defaults_.at(name);
+  });
+}
+
+void
+Properties::setModeProperty(const Mode *mode,
+                            std::string_view property,
+                            std::string_view value)
+{
+  auto di = mode_user_prop_defaults_.find(property);
+  if (di == mode_user_prop_defaults_.end())
+    sta_->report()->error(2212, "mode property '{}' is not defined.", property);
+  mode_user_props_[mode][std::string(property)] =
+    coerceUserValue(di->second.type(), value);
+}
+
+////////////////////////////////////////////////////////////////
+
 template<class TYPE>
 PropertyValue
 PropertyRegistry<TYPE>::getProperty(TYPE object,

--- a/search/Property.cc
+++ b/search/Property.cc
@@ -1390,7 +1390,7 @@ Properties::defineProperty(std::string_view property,
 ////////////////////////////////////////////////////////////////
 
 PropertyValue
-Properties::userPropertyDefault(std::string_view type)
+Properties::propertyDefault(std::string_view type)
 {
   if (type == "bool" || type == "boolean")
     return PropertyValue(false);
@@ -1405,7 +1405,7 @@ Properties::userPropertyDefault(std::string_view type)
 }
 
 PropertyValue
-Properties::coerceUserValue(PropertyValue::Type type,
+Properties::coercePropertyValue(PropertyValue::Type type,
                             std::string_view value)
 {
   switch (type) {
@@ -1420,7 +1420,7 @@ Properties::coerceUserValue(PropertyValue::Type type,
   }
 }
 
-UserPropertyKey::UserPropertyKey(const void *object,
+PropertyKey::PropertyKey(const void *object,
                                  std::string_view object_type,
                                  std::string_view property) :
   object_(object),
@@ -1430,7 +1430,7 @@ UserPropertyKey::UserPropertyKey(const void *object,
 }
 
 bool
-UserPropertyKey::operator<(const UserPropertyKey &key) const
+PropertyKey::operator<(const PropertyKey &key) const
 {
   return std::tie(object_, object_type_, property_)
     < std::tie(key.object_, key.object_type_, key.property_);
@@ -1438,19 +1438,19 @@ UserPropertyKey::operator<(const UserPropertyKey &key) const
 
 template<class TYPE>
 void
-Properties::defineUserProperty(std::string_view object_type,
+Properties::defineProperty(std::string_view object_type,
                                std::string_view property,
                                std::string_view value_type)
 {
-  PropertyValue default_value = userPropertyDefault(value_type);
-  user_prop_values_[UserPropertyKey(nullptr, object_type, property)] = default_value;
+  PropertyValue default_value = propertyDefault(value_type);
+  prop_values_[PropertyKey(nullptr, object_type, property)] = default_value;
   std::string type_name(object_type);
   std::string name(property);
   typename PropertyRegistry<const TYPE *>::PropertyHandler handler =
     [this, type_name, name, default_value] (const TYPE *object,
                                             Sta *) -> PropertyValue {
-      auto value_iter = user_prop_values_.find(UserPropertyKey(object, type_name, name));
-      if (value_iter != user_prop_values_.end())
+      auto value_iter = prop_values_.find(PropertyKey(object, type_name, name));
+      if (value_iter != prop_values_.end())
         return value_iter->second;
       // Unset on this object: the type default seeded at define time.
       return default_value;
@@ -1459,26 +1459,26 @@ Properties::defineUserProperty(std::string_view object_type,
 }
 
 // Object types the tcl interface exposes user properties on.
-template void Properties::defineUserProperty<Scene>(std::string_view,
+template void Properties::defineProperty<Scene>(std::string_view,
                                                     std::string_view,
                                                     std::string_view);
-template void Properties::defineUserProperty<Mode>(std::string_view,
+template void Properties::defineProperty<Mode>(std::string_view,
                                                    std::string_view,
                                                    std::string_view);
 
 void
-Properties::setUserProperty(const void *object,
+Properties::setProperty(const void *object,
                             std::string_view object_type,
                             std::string_view property,
                             std::string_view value)
 {
-  auto default_iter = user_prop_values_.find(UserPropertyKey(nullptr, object_type,
+  auto default_iter = prop_values_.find(PropertyKey(nullptr, object_type,
                                                              property));
-  if (default_iter == user_prop_values_.end())
+  if (default_iter == prop_values_.end())
     sta_->report()->error(2211, "{} property '{}' is not defined.",
                           object_type, property);
-  user_prop_values_[UserPropertyKey(object, object_type, property)] =
-    coerceUserValue(default_iter->second.type(), value);
+  prop_values_[PropertyKey(object, object_type, property)] =
+    coercePropertyValue(default_iter->second.type(), value);
 }
 
 ////////////////////////////////////////////////////////////////

--- a/search/Property.cc
+++ b/search/Property.cc
@@ -1204,8 +1204,14 @@ Properties::getProperty(const Scene *scene,
   if (property == "name"
       || property == "full_name")
     return PropertyValue(scene->name());
-  else
-    throw PropertyUnknown("scene", property);
+  else {
+    PropertyValue value = registry_scene_.getProperty(scene, property,
+                                                      "scene", sta_);
+    if (value.type() != PropertyValue::Type::none)
+      return value;
+    else
+      throw PropertyUnknown("scene", property);
+  }
 }
 
 ////////////////////////////////////////////////////////////////
@@ -1217,8 +1223,14 @@ Properties::getProperty(const Mode *mode,
   if (property == "name"
       || property == "full_name")
     return PropertyValue(mode->name());
-  else
-    throw PropertyUnknown("mode", property);
+  else {
+    PropertyValue value = registry_mode_.getProperty(mode, property,
+                                                     "mode", sta_);
+    if (value.type() != PropertyValue::Type::none)
+      return value;
+    else
+      throw PropertyUnknown("mode", property);
+  }
 }
 
 ////////////////////////////////////////////////////////////////
@@ -1358,6 +1370,20 @@ Properties::defineProperty(std::string_view property,
                            const PropertyRegistry<const Clock *>::PropertyHandler &handler)
 {
   registry_clock_.defineProperty(property, handler);
+}
+
+void
+Properties::defineProperty(std::string_view property,
+                           const PropertyRegistry<const Scene *>::PropertyHandler &handler)
+{
+  registry_scene_.defineProperty(property, handler);
+}
+
+void
+Properties::defineProperty(std::string_view property,
+                           const PropertyRegistry<const Mode *>::PropertyHandler &handler)
+{
+  registry_mode_.defineProperty(property, handler);
 }
 
 ////////////////////////////////////////////////////////////////

--- a/search/Property.cc
+++ b/search/Property.cc
@@ -1399,7 +1399,7 @@ Properties::propertyType(std::string_view type)
 
 PropertyValue
 Properties::coercePropertyValue(PropertyValue::Type type,
-                            std::string_view value)
+                                std::string_view value)
 {
   switch (type) {
   case PropertyValue::Type::bool_:

--- a/search/Property.cc
+++ b/search/Property.cc
@@ -1205,14 +1205,10 @@ Properties::getProperty(const Scene *scene,
   if (property == "name"
       || property == "full_name")
     return PropertyValue(scene->name());
-  else {
-    PropertyValue value = registry_scene_.getProperty(scene, property,
-                                                      "scene", sta_);
-    if (value.type() != PropertyValue::Type::none)
-      return value;
-    else
-      throw PropertyUnknown("scene", property);
-  }
+  else
+    // Unknown properties throw PropertyUnknown; a user-defined property
+    // never set on this scene returns a none value.
+    return registry_scene_.getProperty(scene, property, "scene", sta_);
 }
 
 ////////////////////////////////////////////////////////////////
@@ -1224,14 +1220,10 @@ Properties::getProperty(const Mode *mode,
   if (property == "name"
       || property == "full_name")
     return PropertyValue(mode->name());
-  else {
-    PropertyValue value = registry_mode_.getProperty(mode, property,
-                                                     "mode", sta_);
-    if (value.type() != PropertyValue::Type::none)
-      return value;
-    else
-      throw PropertyUnknown("mode", property);
-  }
+  else
+    // Unknown properties throw PropertyUnknown; a user-defined property
+    // never set on this mode returns a none value.
+    return registry_mode_.getProperty(mode, property, "mode", sta_);
 }
 
 ////////////////////////////////////////////////////////////////
@@ -1389,8 +1381,10 @@ Properties::defineProperty(std::string_view property,
 
 ////////////////////////////////////////////////////////////////
 
+// Empty value of the named type, stored under the null-object key as the
+// property's type record.
 PropertyValue
-Properties::propertyDefault(std::string_view type)
+Properties::propertyTypeValue(std::string_view type)
 {
   if (type == "bool" || type == "boolean")
     return PropertyValue(false);
@@ -1410,10 +1404,17 @@ Properties::coercePropertyValue(PropertyValue::Type type,
 {
   switch (type) {
   case PropertyValue::Type::bool_:
-    return PropertyValue(value == "true" || value == "1");
+    if (stringEqual(value, "true") || value == "1")
+      return PropertyValue(true);
+    if (stringEqual(value, "false") || value == "0")
+      return PropertyValue(false);
+    sta_->report()->error(2212, "'{}' is not a bool property value.", value);
+    return PropertyValue();
   case PropertyValue::Type::float_: {
     auto [number, valid] = stringFloat(std::string(value));
-    return PropertyValue(valid ? number : 0.0f, sta_->units()->scalarUnit());
+    if (!valid)
+      sta_->report()->error(2215, "'{}' is not a float property value.", value);
+    return PropertyValue(number, sta_->units()->scalarUnit());
   }
   default:
     return PropertyValue(std::string(value));
@@ -1442,18 +1443,18 @@ Properties::defineProperty(std::string_view object_type,
                                std::string_view property,
                                std::string_view value_type)
 {
-  PropertyValue default_value = propertyDefault(value_type);
-  prop_values_[PropertyKey(nullptr, object_type, property)] = default_value;
+  prop_values_[PropertyKey(nullptr, object_type, property)] =
+    propertyTypeValue(value_type);
   std::string type_name(object_type);
   std::string name(property);
   typename PropertyRegistry<const TYPE *>::PropertyHandler handler =
-    [this, type_name, name, default_value] (const TYPE *object,
-                                            Sta *) -> PropertyValue {
+    [this, type_name, name] (const TYPE *object,
+                             Sta *) -> PropertyValue {
       auto value_iter = prop_values_.find(PropertyKey(object, type_name, name));
       if (value_iter != prop_values_.end())
         return value_iter->second;
-      // Unset on this object: the type default seeded at define time.
-      return default_value;
+      // Never set on this object.
+      return PropertyValue();
     };
   defineProperty(property, handler);
 }
@@ -1472,13 +1473,13 @@ Properties::setProperty(const void *object,
                             std::string_view property,
                             std::string_view value)
 {
-  auto default_iter = prop_values_.find(PropertyKey(nullptr, object_type,
-                                                             property));
-  if (default_iter == prop_values_.end())
+  auto type_iter = prop_values_.find(PropertyKey(nullptr, object_type,
+                                                 property));
+  if (type_iter == prop_values_.end())
     sta_->report()->error(2211, "{} property '{}' is not defined.",
                           object_type, property);
   prop_values_[PropertyKey(object, object_type, property)] =
-    coercePropertyValue(default_iter->second.type(), value);
+    coercePropertyValue(type_iter->second.type(), value);
 }
 
 ////////////////////////////////////////////////////////////////

--- a/search/Property.cc
+++ b/search/Property.cc
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <string>
+#include <tuple>
 #include <utility>
 
 #include "Clock.hh"
@@ -1419,66 +1420,65 @@ Properties::coerceUserValue(PropertyValue::Type type,
   }
 }
 
-void
-Properties::defineSceneProperty(std::string_view property,
-                                std::string_view type)
+UserPropertyKey::UserPropertyKey(const void *object,
+                                 std::string_view object_type,
+                                 std::string_view property) :
+  object_(object),
+  object_type_(object_type),
+  property_(property)
 {
+}
+
+bool
+UserPropertyKey::operator<(const UserPropertyKey &key) const
+{
+  return std::tie(object_, object_type_, property_)
+    < std::tie(key.object_, key.object_type_, key.property_);
+}
+
+template<class TYPE>
+void
+Properties::defineUserProperty(std::string_view object_type,
+                               std::string_view property,
+                               std::string_view value_type)
+{
+  PropertyValue default_value = userPropertyDefault(value_type);
+  user_prop_values_[UserPropertyKey(nullptr, object_type, property)] = default_value;
+  std::string type_name(object_type);
   std::string name(property);
-  scene_user_prop_defaults_[name] = userPropertyDefault(type);
-  defineProperty(property,
-                 [this, name] (const Scene *scene, Sta *) -> PropertyValue {
-    auto oi = scene_user_props_.find(scene);
-    if (oi != scene_user_props_.end()) {
-      auto pi = oi->second.find(name);
-      if (pi != oi->second.end())
-        return pi->second;
-    }
-    // Unset on this scene: fall back to the type default seeded by define.
-    return scene_user_prop_defaults_.at(name);
-  });
+  typename PropertyRegistry<const TYPE *>::PropertyHandler handler =
+    [this, type_name, name, default_value] (const TYPE *object,
+                                            Sta *) -> PropertyValue {
+      auto value_iter = user_prop_values_.find(UserPropertyKey(object, type_name, name));
+      if (value_iter != user_prop_values_.end())
+        return value_iter->second;
+      // Unset on this object: the type default seeded at define time.
+      return default_value;
+    };
+  defineProperty(property, handler);
 }
 
-void
-Properties::setSceneProperty(const Scene *scene,
-                             std::string_view property,
-                             std::string_view value)
-{
-  auto di = scene_user_prop_defaults_.find(property);
-  if (di == scene_user_prop_defaults_.end())
-    sta_->report()->error(2211, "scene property '{}' is not defined.", property);
-  scene_user_props_[scene][std::string(property)] =
-    coerceUserValue(di->second.type(), value);
-}
+// Object types the tcl interface exposes user properties on.
+template void Properties::defineUserProperty<Scene>(std::string_view,
+                                                    std::string_view,
+                                                    std::string_view);
+template void Properties::defineUserProperty<Mode>(std::string_view,
+                                                   std::string_view,
+                                                   std::string_view);
 
 void
-Properties::defineModeProperty(std::string_view property,
-                               std::string_view type)
-{
-  std::string name(property);
-  mode_user_prop_defaults_[name] = userPropertyDefault(type);
-  defineProperty(property,
-                 [this, name] (const Mode *mode, Sta *) -> PropertyValue {
-    auto oi = mode_user_props_.find(mode);
-    if (oi != mode_user_props_.end()) {
-      auto pi = oi->second.find(name);
-      if (pi != oi->second.end())
-        return pi->second;
-    }
-    // Unset on this mode: fall back to the type default seeded by define.
-    return mode_user_prop_defaults_.at(name);
-  });
-}
-
-void
-Properties::setModeProperty(const Mode *mode,
+Properties::setUserProperty(const void *object,
+                            std::string_view object_type,
                             std::string_view property,
                             std::string_view value)
 {
-  auto di = mode_user_prop_defaults_.find(property);
-  if (di == mode_user_prop_defaults_.end())
-    sta_->report()->error(2212, "mode property '{}' is not defined.", property);
-  mode_user_props_[mode][std::string(property)] =
-    coerceUserValue(di->second.type(), value);
+  auto default_iter = user_prop_values_.find(UserPropertyKey(nullptr, object_type,
+                                                             property));
+  if (default_iter == user_prop_values_.end())
+    sta_->report()->error(2211, "{} property '{}' is not defined.",
+                          object_type, property);
+  user_prop_values_[UserPropertyKey(object, object_type, property)] =
+    coerceUserValue(default_iter->second.type(), value);
 }
 
 ////////////////////////////////////////////////////////////////

--- a/search/Property.cc
+++ b/search/Property.cc
@@ -1381,21 +1381,20 @@ Properties::defineProperty(std::string_view property,
 
 ////////////////////////////////////////////////////////////////
 
-// Empty value of the named type, stored under the null-object key as the
-// property's type record.
-PropertyValue
-Properties::propertyTypeValue(std::string_view type)
+// Value type from the define_property -type argument.
+PropertyValue::Type
+Properties::propertyType(std::string_view type)
 {
   if (type == "bool" || type == "boolean")
-    return PropertyValue(false);
+    return PropertyValue::Type::bool_;
   else if (type == "float" || type == "double" || type == "number")
-    return PropertyValue(0.0f, sta_->units()->scalarUnit());
+    return PropertyValue::Type::float_;
   else if (type == "string")
-    return PropertyValue(std::string());
+    return PropertyValue::Type::string;
   else
     sta_->report()->error(2210, "unknown property type '{}' (use bool, float or string).",
                           type);
-  return PropertyValue();
+  return PropertyValue::Type::none;
 }
 
 PropertyValue
@@ -1422,10 +1421,8 @@ Properties::coercePropertyValue(PropertyValue::Type type,
 }
 
 PropertyKey::PropertyKey(const void *object,
-                                 std::string_view object_type,
-                                 std::string_view property) :
+                         std::string_view property) :
   object_(object),
-  object_type_(object_type),
   property_(property)
 {
 }
@@ -1433,24 +1430,23 @@ PropertyKey::PropertyKey(const void *object,
 bool
 PropertyKey::operator<(const PropertyKey &key) const
 {
-  return std::tie(object_, object_type_, property_)
-    < std::tie(key.object_, key.object_type_, key.property_);
+  return std::tie(object_, property_)
+    < std::tie(key.object_, key.property_);
 }
 
 template<class TYPE>
 void
 Properties::defineProperty(std::string_view object_type,
-                               std::string_view property,
-                               std::string_view value_type)
+                           std::string_view property,
+                           std::string_view value_type)
 {
-  prop_values_[PropertyKey(nullptr, object_type, property)] =
-    propertyTypeValue(value_type);
-  std::string type_name(object_type);
+  prop_types_[{std::string(object_type), std::string(property)}] =
+    propertyType(value_type);
   std::string name(property);
   typename PropertyRegistry<const TYPE *>::PropertyHandler handler =
-    [this, type_name, name] (const TYPE *object,
-                             Sta *) -> PropertyValue {
-      auto value_iter = prop_values_.find(PropertyKey(object, type_name, name));
+    [this, name] (const TYPE *object,
+                  Sta *) -> PropertyValue {
+      auto value_iter = prop_values_.find(PropertyKey(object, name));
       if (value_iter != prop_values_.end())
         return value_iter->second;
       // Never set on this object.
@@ -1461,25 +1457,25 @@ Properties::defineProperty(std::string_view object_type,
 
 // Object types the tcl interface exposes user properties on.
 template void Properties::defineProperty<Scene>(std::string_view,
-                                                    std::string_view,
-                                                    std::string_view);
+                                                std::string_view,
+                                                std::string_view);
 template void Properties::defineProperty<Mode>(std::string_view,
-                                                   std::string_view,
-                                                   std::string_view);
+                                               std::string_view,
+                                               std::string_view);
 
 void
 Properties::setProperty(const void *object,
-                            std::string_view object_type,
-                            std::string_view property,
-                            std::string_view value)
+                        std::string_view object_type,
+                        std::string_view property,
+                        std::string_view value)
 {
-  auto type_iter = prop_values_.find(PropertyKey(nullptr, object_type,
-                                                 property));
-  if (type_iter == prop_values_.end())
+  auto type_iter = prop_types_.find({std::string(object_type),
+                                     std::string(property)});
+  if (type_iter == prop_types_.end())
     sta_->report()->error(2211, "{} property '{}' is not defined.",
                           object_type, property);
-  prop_values_[PropertyKey(object, object_type, property)] =
-    coercePropertyValue(type_iter->second.type(), value);
+  prop_values_[PropertyKey(object, property)] =
+    coercePropertyValue(type_iter->second, value);
 }
 
 ////////////////////////////////////////////////////////////////

--- a/search/Property.i
+++ b/search/Property.i
@@ -139,23 +139,23 @@ mode_property(Mode *mode,
 }
 
 void
-define_user_property_cmd(const char *object_type,
+define_property_cmd(const char *object_type,
                          const char *property,
                          const char *type)
 {
   Properties &properties = Sta::sta()->properties();
   std::string_view object_type_view(object_type);
   if (object_type_view == "scene")
-    properties.defineUserProperty<Scene>(object_type, property, type);
+    properties.defineProperty<Scene>(object_type, property, type);
   else if (object_type_view == "mode")
-    properties.defineUserProperty<Mode>(object_type, property, type);
+    properties.defineProperty<Mode>(object_type, property, type);
   else
-    Sta::sta()->report()->error(2209, "define_user_property -object_type {} not supported.",
+    Sta::sta()->report()->error(2209, "define_property -object_type {} not supported.",
                                 object_type);
 }
 
 void
-set_user_property_cmd(void *object,
+set_property_cmd(void *object,
                       const char *object_type,
                       const char *property,
                       const char *value)
@@ -163,11 +163,11 @@ set_user_property_cmd(void *object,
   Properties &properties = Sta::sta()->properties();
   std::string_view object_type_view(object_type);
   if (object_type_view == "Scene")
-    properties.setUserProperty(object, "scene", property, value);
+    properties.setProperty(object, "scene", property, value);
   else if (object_type_view == "Mode")
-    properties.setUserProperty(object, "mode", property, value);
+    properties.setProperty(object, "mode", property, value);
   else
-    Sta::sta()->report()->error(2214, "set_user_property unsupported object type {}.",
+    Sta::sta()->report()->error(2214, "set_property unsupported object type {}.",
                                 object_type);
 }
 

--- a/search/Property.i
+++ b/search/Property.i
@@ -137,6 +137,40 @@ mode_property(Mode *mode,
   return properties.getProperty(mode, property);
 }
 
+void
+define_scene_user_property(const char *property,
+                           const char *type)
+{
+  Properties &properties = Sta::sta()->properties();
+  properties.defineSceneProperty(property, type);
+}
+
+void
+set_scene_user_property(Scene *scene,
+                        const char *property,
+                        const char *value)
+{
+  Properties &properties = Sta::sta()->properties();
+  properties.setSceneProperty(scene, property, value);
+}
+
+void
+define_mode_user_property(const char *property,
+                          const char *type)
+{
+  Properties &properties = Sta::sta()->properties();
+  properties.defineModeProperty(property, type);
+}
+
+void
+set_mode_user_property(Mode *mode,
+                       const char *property,
+                       const char *value)
+{
+  Properties &properties = Sta::sta()->properties();
+  properties.setModeProperty(mode, property, value);
+}
+
 PropertyValue
 path_end_property(PathEnd *end,
                   const char *property)

--- a/search/Property.i
+++ b/search/Property.i
@@ -25,6 +25,7 @@
 %{
 
 #include "Property.hh"
+#include "Report.hh"
 #include "Sta.hh"
 
 using namespace sta;
@@ -138,37 +139,36 @@ mode_property(Mode *mode,
 }
 
 void
-define_scene_user_property(const char *property,
-                           const char *type)
+define_user_property_cmd(const char *object_type,
+                         const char *property,
+                         const char *type)
 {
   Properties &properties = Sta::sta()->properties();
-  properties.defineSceneProperty(property, type);
+  std::string_view object_type_view(object_type);
+  if (object_type_view == "scene")
+    properties.defineUserProperty<Scene>(object_type, property, type);
+  else if (object_type_view == "mode")
+    properties.defineUserProperty<Mode>(object_type, property, type);
+  else
+    Sta::sta()->report()->error(2209, "define_user_property -object_type {} not supported.",
+                                object_type);
 }
 
 void
-set_scene_user_property(Scene *scene,
-                        const char *property,
-                        const char *value)
+set_user_property_cmd(void *object,
+                      const char *object_type,
+                      const char *property,
+                      const char *value)
 {
   Properties &properties = Sta::sta()->properties();
-  properties.setSceneProperty(scene, property, value);
-}
-
-void
-define_mode_user_property(const char *property,
-                          const char *type)
-{
-  Properties &properties = Sta::sta()->properties();
-  properties.defineModeProperty(property, type);
-}
-
-void
-set_mode_user_property(Mode *mode,
-                       const char *property,
-                       const char *value)
-{
-  Properties &properties = Sta::sta()->properties();
-  properties.setModeProperty(mode, property, value);
+  std::string_view object_type_view(object_type);
+  if (object_type_view == "Scene")
+    properties.setUserProperty(object, "scene", property, value);
+  else if (object_type_view == "Mode")
+    properties.setUserProperty(object, "mode", property, value);
+  else
+    Sta::sta()->report()->error(2214, "set_user_property unsupported object type {}.",
+                                object_type);
 }
 
 PropertyValue

--- a/search/Property.i
+++ b/search/Property.i
@@ -140,8 +140,8 @@ mode_property(Mode *mode,
 
 void
 define_property_cmd(const char *object_type,
-                         const char *property,
-                         const char *type)
+                    const char *property,
+                    const char *type)
 {
   Properties &properties = Sta::sta()->properties();
   std::string_view object_type_view(object_type);
@@ -156,9 +156,9 @@ define_property_cmd(const char *object_type,
 
 void
 set_property_cmd(void *object,
-                      const char *object_type,
-                      const char *property,
-                      const char *value)
+                 const char *object_type,
+                 const char *property,
+                 const char *value)
 {
   Properties &properties = Sta::sta()->properties();
   std::string_view object_type_view(object_type);

--- a/tcl/Property.tcl
+++ b/tcl/Property.tcl
@@ -120,5 +120,49 @@ proc get_property_object_type { object_type object_name quiet } {
   return [lindex $object 0]
 }
 
+define_cmd_args "define_user_property" \
+  {-object_type scene|mode -type bool|float|string property}
+
+proc define_user_property { args } {
+  parse_key_args "define_user_property" args keys {-object_type -type} flags {}
+  check_argc_eq1 "define_user_property" $args
+  if { ![info exists keys(-object_type)] } {
+    sta_error 2207 "define_user_property -object_type must be specified."
+  }
+  if { ![info exists keys(-type)] } {
+    sta_error 2208 "define_user_property -type must be specified."
+  }
+  set object_type $keys(-object_type)
+  set type $keys(-type)
+  set prop [lindex $args 0]
+  if { $object_type == "scene" } {
+    define_scene_user_property $prop $type
+  } elseif { $object_type == "mode" } {
+    define_mode_user_property $prop $type
+  } else {
+    sta_error 2209 "define_user_property -object_type $object_type not supported."
+  }
+}
+
+define_cmd_args "set_user_property" {object property value}
+
+proc set_user_property { args } {
+  check_argc_eq3 "set_user_property" $args
+  set object [lindex $args 0]
+  set prop [lindex $args 1]
+  set value [lindex $args 2]
+  if { ![is_object $object] } {
+    sta_error 2213 "set_user_property $object is not an object."
+  }
+  set object_type [object_type $object]
+  if { $object_type == "Scene" } {
+    set_scene_user_property $object $prop $value
+  } elseif { $object_type == "Mode" } {
+    set_mode_user_property $object $prop $value
+  } else {
+    sta_error 2214 "set_user_property unsupported object type $object_type."
+  }
+}
+
 # sta namespace end.
 }

--- a/tcl/Property.tcl
+++ b/tcl/Property.tcl
@@ -120,32 +120,32 @@ proc get_property_object_type { object_type object_name quiet } {
   return [lindex $object 0]
 }
 
-define_cmd_args "define_user_property" \
+define_cmd_args "define_property" \
   {-object_type scene|mode -type bool|float|string property}
 
-proc define_user_property { args } {
-  parse_key_args "define_user_property" args keys {-object_type -type} flags {}
-  check_argc_eq1 "define_user_property" $args
+proc define_property { args } {
+  parse_key_args "define_property" args keys {-object_type -type} flags {}
+  check_argc_eq1 "define_property" $args
   if { ![info exists keys(-object_type)] } {
-    sta_error 2207 "define_user_property -object_type must be specified."
+    sta_error 2207 "define_property -object_type must be specified."
   }
   if { ![info exists keys(-type)] } {
-    sta_error 2208 "define_user_property -type must be specified."
+    sta_error 2208 "define_property -type must be specified."
   }
-  define_user_property_cmd $keys(-object_type) [lindex $args 0] $keys(-type)
+  define_property_cmd $keys(-object_type) [lindex $args 0] $keys(-type)
 }
 
-define_cmd_args "set_user_property" {object property value}
+define_cmd_args "set_property" {object property value}
 
-proc set_user_property { args } {
-  check_argc_eq3 "set_user_property" $args
+proc set_property { args } {
+  check_argc_eq3 "set_property" $args
   set object [lindex $args 0]
   set prop [lindex $args 1]
   set value [lindex $args 2]
   if { ![is_object $object] } {
-    sta_error 2213 "set_user_property $object is not an object."
+    sta_error 2213 "set_property $object is not an object."
   }
-  set_user_property_cmd $object [object_type $object] $prop $value
+  set_property_cmd $object [object_type $object] $prop $value
 }
 
 # sta namespace end.

--- a/tcl/Property.tcl
+++ b/tcl/Property.tcl
@@ -132,16 +132,7 @@ proc define_user_property { args } {
   if { ![info exists keys(-type)] } {
     sta_error 2208 "define_user_property -type must be specified."
   }
-  set object_type $keys(-object_type)
-  set type $keys(-type)
-  set prop [lindex $args 0]
-  if { $object_type == "scene" } {
-    define_scene_user_property $prop $type
-  } elseif { $object_type == "mode" } {
-    define_mode_user_property $prop $type
-  } else {
-    sta_error 2209 "define_user_property -object_type $object_type not supported."
-  }
+  define_user_property_cmd $keys(-object_type) [lindex $args 0] $keys(-type)
 }
 
 define_cmd_args "set_user_property" {object property value}
@@ -154,14 +145,7 @@ proc set_user_property { args } {
   if { ![is_object $object] } {
     sta_error 2213 "set_user_property $object is not an object."
   }
-  set object_type [object_type $object]
-  if { $object_type == "Scene" } {
-    set_scene_user_property $object $prop $value
-  } elseif { $object_type == "Mode" } {
-    set_mode_user_property $object $prop $value
-  } else {
-    sta_error 2214 "set_user_property unsupported object type $object_type."
-  }
+  set_user_property_cmd $object [object_type $object] $prop $value
 }
 
 # sta namespace end.

--- a/tcl/Sta.tcl
+++ b/tcl/Sta.tcl
@@ -112,10 +112,10 @@ proc set_scene { args } {
 
 ################################################################
 
-define_cmd_args "get_scenes" {[-modes mode_names] scene_names}
+define_cmd_args "get_scenes" {[-modes mode_names] [-filter expr] scene_names}
 
 proc get_scenes { args } {
-  parse_key_args "get_scenes" args keys {-modes} flags {}
+  parse_key_args "get_scenes" args keys {-modes -filter} flags {}
   check_argc_eq0or1 "get_scenes" $args
 
   if { [llength $args] == 0 } {
@@ -132,18 +132,34 @@ proc get_scenes { args } {
       }
       lappend modes $mode
     }
-    return [find_mode_scenes_matching $scene_name $modes]
+    set scenes [find_mode_scenes_matching $scene_name $modes]
   } else {
-    return [find_scenes_matching $scene_name]
+    set scenes [find_scenes_matching $scene_name]
   }
+  if { [info exists keys(-filter)] } {
+    set scenes [filter_scenes $keys(-filter) $scenes]
+  }
+  return $scenes
 }
 
 ################################################################
 
-define_cmd_args "get_modes" {mode_name}
+define_cmd_args "get_modes" {[-filter expr] [mode_name]}
 
 proc get_modes { args } {
-  return [find_modes [lindex $args 0]]
+  parse_key_args "get_modes" args keys {-filter} flags {}
+  check_argc_eq0or1 "get_modes" $args
+
+  if { [llength $args] == 0 } {
+    set mode_name "*"
+  } else {
+    set mode_name [lindex $args 0]
+  }
+  set modes [find_modes $mode_name]
+  if { [info exists keys(-filter)] } {
+    set modes [filter_modes $keys(-filter) $modes]
+  }
+  return $modes
 }
 
 ################################################################

--- a/tcl/StaTclTypes.i
+++ b/tcl/StaTclTypes.i
@@ -1218,6 +1218,10 @@ using namespace sta;
   $1 = tclListSeq<Mode*>($input, SWIGTYPE_p_Mode, interp);
 }
 
+%typemap(in) ModeSeq* {
+  $1 = tclListSeqPtr<Mode*>($input, SWIGTYPE_p_Mode, interp);
+}
+
 %typemap(out) ModeSeq {
   seqTclList<ModeSeq, Mode>($1, SWIGTYPE_p_Mode, interp);
 }
@@ -1249,6 +1253,10 @@ using namespace sta;
 
 %typemap(in) SceneSeq {
   $1 = tclListSeq<Scene*>($input, SWIGTYPE_p_Scene, interp);
+}
+
+%typemap(in) SceneSeq* {
+  $1 = tclListSeqPtr<Scene*>($input, SWIGTYPE_p_Scene, interp);
 }
 
 %typemap(out) SceneSeq {

--- a/test/get_scenes.ok
+++ b/test/get_scenes.ok
@@ -16,3 +16,15 @@ mode2
 [get_modes -filter {name =~ mode*}]
 mode1
 mode2
+[get_property scene1 active]
+1
+[get_property scene2 active]
+0
+[get_scenes -filter {active == true}]
+scene1
+[get_scenes -filter {active == false}]
+scene2
+[get_scenes -filter {active}]
+scene1
+[get_scenes -filter {!active}]
+scene2

--- a/test/get_scenes.ok
+++ b/test/get_scenes.ok
@@ -18,13 +18,16 @@ mode1
 mode2
 [get_property scene1 active]
 1
-[get_property scene2 active]
-0
+[get_property scene2 active] (unset)
+<>
 [get_scenes -filter {active == true}]
 scene1
-[get_scenes -filter {active == false}]
-scene2
+[get_scenes -filter {active == false}] (scene2 unset)
 [get_scenes -filter {active}]
 scene1
 [get_scenes -filter {!active}]
+scene2
+[get_property scene2 active] (set false)
+0
+[get_scenes -filter {active == false}] (scene2 set false)
 scene2

--- a/test/get_scenes.ok
+++ b/test/get_scenes.ok
@@ -4,3 +4,15 @@ scene2
 [get_modes *]
 mode1
 mode2
+[get_scenes -filter {name == scene1}]
+scene1
+[get_scenes -filter {name =~ scene*}]
+scene1
+scene2
+[get_scenes -filter {name != scene1}]
+scene2
+[get_modes -filter {name == mode2}]
+mode2
+[get_modes -filter {name =~ mode*}]
+mode1
+mode2

--- a/test/get_scenes.tcl
+++ b/test/get_scenes.tcl
@@ -33,3 +33,24 @@ report_object_names [get_modes -filter {name == mode2}]
 
 puts {[get_modes -filter {name =~ mode*}]}
 report_object_names [get_modes -filter {name =~ mode*}]
+
+# User-defined bool property. scene1 set active, scene2 left at default (false).
+define_user_property -object_type scene -type bool active
+set_user_property [get_scenes scene1] active true
+
+puts {[get_property scene1 active]}
+puts [get_property [get_scenes scene1] active]
+puts {[get_property scene2 active]}
+puts [get_property [get_scenes scene2] active]
+
+puts {[get_scenes -filter {active == true}]}
+report_object_names [get_scenes -filter {active == true}]
+
+puts {[get_scenes -filter {active == false}]}
+report_object_names [get_scenes -filter {active == false}]
+
+puts {[get_scenes -filter {active}]}
+report_object_names [get_scenes -filter {active}]
+
+puts {[get_scenes -filter {!active}]}
+report_object_names [get_scenes -filter {!active}]

--- a/test/get_scenes.tcl
+++ b/test/get_scenes.tcl
@@ -35,8 +35,8 @@ puts {[get_modes -filter {name =~ mode*}]}
 report_object_names [get_modes -filter {name =~ mode*}]
 
 # User-defined bool property. scene1 set active, scene2 left at default (false).
-define_user_property -object_type scene -type bool active
-set_user_property [get_scenes scene1] active true
+define_property -object_type scene -type bool active
+set_property [get_scenes scene1] active true
 
 puts {[get_property scene1 active]}
 puts [get_property [get_scenes scene1] active]

--- a/test/get_scenes.tcl
+++ b/test/get_scenes.tcl
@@ -18,3 +18,18 @@ report_object_names [get_scenes *]
 
 puts {[get_modes *]}
 report_object_names [get_modes *]
+
+puts {[get_scenes -filter {name == scene1}]}
+report_object_names [get_scenes -filter {name == scene1}]
+
+puts {[get_scenes -filter {name =~ scene*}]}
+report_object_names [get_scenes -filter {name =~ scene*}]
+
+puts {[get_scenes -filter {name != scene1}]}
+report_object_names [get_scenes -filter {name != scene1}]
+
+puts {[get_modes -filter {name == mode2}]}
+report_object_names [get_modes -filter {name == mode2}]
+
+puts {[get_modes -filter {name =~ mode*}]}
+report_object_names [get_modes -filter {name =~ mode*}]

--- a/test/get_scenes.tcl
+++ b/test/get_scenes.tcl
@@ -34,19 +34,20 @@ report_object_names [get_modes -filter {name == mode2}]
 puts {[get_modes -filter {name =~ mode*}]}
 report_object_names [get_modes -filter {name =~ mode*}]
 
-# User-defined bool property. scene1 set active, scene2 left at default (false).
+# User-defined bool property. scene1 set active, scene2 left unset.
 define_property -object_type scene -type bool active
 set_property [get_scenes scene1] active true
 
 puts {[get_property scene1 active]}
 puts [get_property [get_scenes scene1] active]
-puts {[get_property scene2 active]}
-puts [get_property [get_scenes scene2] active]
+puts {[get_property scene2 active] (unset)}
+puts "<[get_property [get_scenes scene2] active]>"
 
 puts {[get_scenes -filter {active == true}]}
 report_object_names [get_scenes -filter {active == true}]
 
-puts {[get_scenes -filter {active == false}]}
+# Unset does not match false; only an explicitly set value does.
+puts {[get_scenes -filter {active == false}] (scene2 unset)}
 report_object_names [get_scenes -filter {active == false}]
 
 puts {[get_scenes -filter {active}]}
@@ -54,3 +55,10 @@ report_object_names [get_scenes -filter {active}]
 
 puts {[get_scenes -filter {!active}]}
 report_object_names [get_scenes -filter {!active}]
+
+set_property [get_scenes scene2] active false
+puts {[get_property scene2 active] (set false)}
+puts [get_property [get_scenes scene2] active]
+
+puts {[get_scenes -filter {active == false}] (scene2 set false)}
+report_object_names [get_scenes -filter {active == false}]


### PR DESCRIPTION
**Summary**

  Adds a -filter <expr> option to get_scenes and get_modes, matching the existing get_clocks/get_cells/etc. commands, and makes Scene/Mode properties extensible at runtime via the property registry (as Clock and the other object types already are).
  Filtering reuses the shared filterObjects<T> mechanism - no new filtering path.

Two commits specific to 2 features:

**(1)   -filter support**

  - include/sta/FilterObjects.hh, sdc/FilterObjects.cc - filterScenes / filterModes, each a filterObjects<Scene> / filterObjects<Mode> instantiation with a name-based sort comparator (mirrors filterClocks).
  - sdc/Sdc.i - filter_scenes / filter_modes SWIG wrappers.
  - tcl/StaTclTypes.i - %typemap(in) for SceneSeq* / ModeSeq* (pointer input via tclListSeqPtr); only by-value-in and out typemaps existed, and the filter_*(const char*, Seq*) signature requires the pointer-in form.
  - tcl/Sta.tcl - -filter key on both procs, applied after object resolution. get_modes reworked to parse_key_args + check_argc_eq0or1, defaulting the pattern to * when no arg is given (previously "", which matched nothing).

**(2)  Extensible Scene/Mode properties**

  - include/sta/Property.hh - defineProperty overloads for const Scene* / const Mode*; registry_scene_ / registry_mode_ members.
  - search/Property.cc - getProperty(const Scene*/Mode*) now falls back to the registry before throwing PropertyUnknown; defineProperty(Scene*/Mode*) bodies delegate to the registries.

 Lookup order now matches Clock: built-in name/full_name --> registry --> PropertyUnknown.

 **Result**

  Scene/Mode currently expose only name/full_name as built-ins, but a host (e.g. OpenROAD) can now register custom  Scene/Mode properties via defineProperty, and get_scenes -filter / get_modes -filter query them automatically - the filter layer needs no  per-property changes (unless a property introduces an entirely new PropertyValue::Type, which requires a case in the defined()/undefined() switch, as for every object type).

 **Tests**

  - test/get_scenes.tcl / .ok - added -filter coverage: scenes == / =~ / !=, modes == / =~.
