### PR TITLE
SMALLFIX: Use reliable mirrors for Bison and TCL in CentOS 7 Dockerfile

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -17,7 +17,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
 RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake
 
 # Download Bison
-RUN wget https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz && \
+RUN wget https://mirrors.dotsrc.org/gnu/bison/bison-3.8.2.tar.gz && \
     tar -xvf bison-3.8.2.tar.gz && \
     rm bison-3.8.2.tar.gz
 
@@ -42,7 +42,7 @@ RUN source /opt/rh/devtoolset-11/enable && \
     make install
 
 # Download TCL
-RUN wget http://prdownloads.sourceforge.net/tcl/tcl8.6.16-src.tar.gz && \
+RUN wget https://ftp.osuosl.org/pub/lfs/lfs-packages/12.3-rc2/tcl8.6.16-src.tar.gz && \
     tar -xvf tcl8.6.16-src.tar.gz && \
     rm tcl8.6.16-src.tar.gz
 

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -17,7 +17,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
 RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake
 
 # Download Bison
-RUN wget https://mirrors.dotsrc.org/gnu/bison/bison-3.8.2.tar.gz && \
+RUN wget https://ftpmirror.gnu.org/gnu/bison/bison-3.8.2.tar.gz && \
     tar -xvf bison-3.8.2.tar.gz && \
     rm bison-3.8.2.tar.gz
 
@@ -42,7 +42,8 @@ RUN source /opt/rh/devtoolset-11/enable && \
     make install
 
 # Download TCL
-RUN wget https://ftp.osuosl.org/pub/lfs/lfs-packages/12.3-rc2/tcl8.6.16-src.tar.gz && \
+RUN wget https://sourceforge.net/projects/tcl/files/Tcl/8.6.16/tcl8.6.16-src.tar.gz/download \
+        -O tcl8.6.16-src.tar.gz && \
     tar -xvf tcl8.6.16-src.tar.gz && \
     rm tcl8.6.16-src.tar.gz
 


### PR DESCRIPTION
## Summary
- Switch CentOS 7 Dockerfile downloads for Bison and TCL off flaky `ftp.gnu.org` / SourceForge `prdownloads` URLs.
- Use `https://ftpmirror.gnu.org` (GNU redirector) for Bison and the SourceForge project download URL for TCL.

## Motivation
These mirrors frequently fail or hang during `docker build`, breaking CentOS 7 based workflows.

## Test plan
- [x] `wget` of both URLs succeeds and yields valid gzip tarballs (`bison-3.8.2`, `tcl8.6.16`)
- [x] `docker build -f Dockerfile.centos7 .` succeeds downloading Bison and TCL