### PR TITLE
SMALLFIX: Honor user activity map in `Power::findActivity`

### DIFF
--- a/power/Power.cc
+++ b/power/Power.cc
@@ -1604,6 +1604,8 @@ Power::findActivity(const Pin *pin)
     if (activity && activity->origin() != PwrActivityOrigin::unknown)
       return *activity;
   }
+  if (hasUserActivity(pin))
+    return userActivity(pin);
   return PwrActivity(0.0, 0.0, PwrActivityOrigin::unknown);
 }
 

--- a/test/find_activity_user.ok
+++ b/test/find_activity_user.ok
@@ -1,0 +1,8 @@
+input           1
+unannotated    19
+Annotated pins:
+ user r1/Q
+     Internal    Switching      Leakage        Total
+        Power        Power        Power        Power (Watts)
+----------------------------------------------------
+ 3.775161e-04 1.505934e-05 4.855328e-10 3.925760e-04 r1

--- a/test/find_activity_user.tcl
+++ b/test/find_activity_user.tcl
@@ -1,0 +1,10 @@
+# Register Q with set_power_activity must be used by findActivity
+# (activity_map_ is not seeded for user-annotated seq outputs).
+read_liberty asap7_small.lib.gz
+read_verilog reg1_asap7.v
+link_design top
+create_clock -name clk -period 10 {clk1 clk2 clk3}
+
+set_power_activity -pins [get_pins r1/Q] -density 0.2 -duty 0.5
+report_activity_annotation -report_annotated
+report_power -digits 6 -instances r1

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -141,6 +141,7 @@ record_example_tests {
 }
 
 record_public_tests {
+  find_activity_user
   disconnect_mcp_pin
   get_filter
   get_is_buffer


### PR DESCRIPTION
## Summary
- Before returning unknown/zero activity, `Power::findActivity` now checks `user_activity_map_` (via `hasUserActivity` / `userActivity`).
- Pins annotated with `set_power_activity` are reported correctly even when activity cannot be propagated (e.g. flop or macro outputs).

## Motivation
User-annotated activities were ignored for pins that never appear in the propagated `activity_map_`, so reports showed 0 / unknown despite explicit annotations.

## Notes
- No dedicated regression yet (happy to add one if desired).

## Test plan
- [x] Manually: `set_power_activity` on a flop/macro output, then `report_activity_annotation` / power report shows the user values
- [x] Existing power / VCD regressions still pass

Made with [Cursor](https://cursor.com)