### PR TITLE
feat(ci): expand CI with macOS and CentOS 7 (Docker) platform coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
 
 jobs:
+  # Primary native Linux build used for install artifacts.
   build:
     runs-on: ubuntu-latest
     steps:
@@ -53,3 +54,62 @@ jobs:
           name: result
           path: |
             test/results/*
+
+  # Docker matrix covering packaged/old-platform builds (existing Dockerfiles).
+  linux-docker:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [centos7, ubuntu22.04]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - name: Build image
+        run: |
+          cp Dockerfile.${{ matrix.os }} Dockerfile
+          docker build --tag sta-${{ matrix.os }} .
+
+      - name: Test in container
+        run: |
+          docker run --entrypoint /bin/bash --rm sta-${{ matrix.os }} \
+            -c "cd /OpenSTA/test && ./regression || (cat results/diffs && exit 1)"
+
+  # Native macOS coverage via Brewfile.
+  macos:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - name: Install dependencies
+        run: |
+          brew trust --formula mht208/formal/cudd || true
+          brew bundle
+
+      - name: Build
+        run: |
+          eval "$(/opt/homebrew/bin/brew shellenv)"
+          export PATH="$(brew --prefix flex)/bin:$PATH"
+          export PATH="$(brew --prefix bison)/bin:$PATH"
+          export TCL_LIBRARY="$(brew --prefix tcl-tk@8)/lib/libtcl8.6.dylib"
+          export TCL_INCLUDE_PATH="$(brew --prefix tcl-tk@8)/include/tcl-tk"
+          export FLEX_INCLUDE_DIR="$(brew --prefix flex)/include"
+          cmake -S . -B build \
+            -D TCL_LIBRARY=$TCL_LIBRARY \
+            -D TCL_INCLUDE_PATH=$TCL_INCLUDE_PATH \
+            -D FLEX_INCLUDE_DIR=$FLEX_INCLUDE_DIR \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build -j "$(sysctl -n hw.ncpu)"
+
+      - name: Test
+        run: |
+          cd test
+          ./regression || (cat results/diffs && exit 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [centos7, ubuntu22.04]
+        os: [centos7, ubuntu22.04, ubuntu24.04]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -90,9 +90,7 @@ jobs:
           submodules: true
 
       - name: Install dependencies
-        run: |
-          brew trust --formula mht208/formal/cudd || true
-          brew bundle
+        run: brew bundle
 
       - name: Build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   # Primary native Linux build used for install artifacts.
-  build:
+  linux-ubuntu:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -54,10 +54,9 @@ jobs:
           name: result-ubuntu-latest
           path: |
             test/results/*
-          retention-days: 1
 
   # CentOS 7 Docker: old platform still common in EDA environments.
-  linux-docker:
+  linux-centos:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -67,20 +66,15 @@ jobs:
           submodules: true
 
       - name: Build image
-        run: |
-          cp Dockerfile.centos7 Dockerfile
-          docker build --tag sta-centos7 .
+        run: docker build -f Dockerfile.centos7 --tag sta-centos7 .
 
       - name: Test in container
         run: |
-          set +e
-          docker run --name sta-test --entrypoint /bin/bash sta-centos7 \
-            -c "cd /OpenSTA/test && ./regression || (cat results/diffs && exit 1)"
-          status=$?
           mkdir -p test/results
-          docker cp sta-test:/OpenSTA/test/results/. test/results/ || true
-          docker rm -f sta-test || true
-          exit $status
+          docker run --rm \
+            -v "$PWD/test/results:/OpenSTA/test/results" \
+            --entrypoint /bin/bash sta-centos7 \
+            -c "cd /OpenSTA/test && ./regression || (cat results/diffs && exit 1)"
 
       - name: Upload Test Result
         uses: actions/upload-artifact@v7
@@ -89,7 +83,6 @@ jobs:
           name: result-centos7
           path: |
             test/results/*
-          retention-days: 1
 
   # Native macOS coverage via Brewfile.
   macos:
@@ -131,4 +124,3 @@ jobs:
           name: result-macos
           path: |
             test/results/*
-          retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,8 @@ jobs:
             test/results/*
           retention-days: 1
 
-  # Docker matrix covering packaged/old-platform builds (existing Dockerfiles).
+  # CentOS 7 Docker: old platform still common in EDA environments.
   linux-docker:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [centos7, ubuntu22.04, ubuntu24.04]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -72,13 +68,13 @@ jobs:
 
       - name: Build image
         run: |
-          cp Dockerfile.${{ matrix.os }} Dockerfile
-          docker build --tag sta-${{ matrix.os }} .
+          cp Dockerfile.centos7 Dockerfile
+          docker build --tag sta-centos7 .
 
       - name: Test in container
         run: |
           set +e
-          docker run --name sta-test --entrypoint /bin/bash sta-${{ matrix.os }} \
+          docker run --name sta-test --entrypoint /bin/bash sta-centos7 \
             -c "cd /OpenSTA/test && ./regression || (cat results/diffs && exit 1)"
           status=$?
           mkdir -p test/results
@@ -90,7 +86,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
-          name: result-${{ matrix.os }}
+          name: result-centos7
           path: |
             test/results/*
           retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,10 @@ jobs:
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
-          name: result
+          name: result-ubuntu-latest
           path: |
             test/results/*
+          retention-days: 1
 
   # Docker matrix covering packaged/old-platform builds (existing Dockerfiles).
   linux-docker:
@@ -76,8 +77,23 @@ jobs:
 
       - name: Test in container
         run: |
-          docker run --entrypoint /bin/bash --rm sta-${{ matrix.os }} \
+          set +e
+          docker run --name sta-test --entrypoint /bin/bash sta-${{ matrix.os }} \
             -c "cd /OpenSTA/test && ./regression || (cat results/diffs && exit 1)"
+          status=$?
+          mkdir -p test/results
+          docker cp sta-test:/OpenSTA/test/results/. test/results/ || true
+          docker rm -f sta-test || true
+          exit $status
+
+      - name: Upload Test Result
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: result-${{ matrix.os }}
+          path: |
+            test/results/*
+          retention-days: 1
 
   # Native macOS coverage via Brewfile.
   macos:
@@ -111,3 +127,12 @@ jobs:
         run: |
           cd test
           ./regression || (cat results/diffs && exit 1)
+
+      - name: Upload Test Result
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: result-macos
+          path: |
+            test/results/*
+          retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
-          name: artifact
+          name: artifact-ubuntu
           path: |
             build/install/*
           retention-days: 1
@@ -51,7 +51,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
-          name: result-ubuntu-latest
+          name: result-ubuntu
           path: |
             test/results/*
 

--- a/Brewfile
+++ b/Brewfile
@@ -6,5 +6,4 @@ brew "swig"
 brew "tcl-tk@8"
 
 tap "mht208/formal"
-# Trust only the CUDD formula (Homebrew tap-trust); brew bundle applies this.
 brew "mht208/formal/cudd", trusted: true

--- a/Brewfile
+++ b/Brewfile
@@ -6,4 +6,5 @@ brew "swig"
 brew "tcl-tk@8"
 
 tap "mht208/formal"
-brew "mht208/formal/cudd"
+# Trust only the CUDD formula (Homebrew tap-trust); brew bundle applies this.
+brew "mht208/formal/cudd", trusted: true


### PR DESCRIPTION
## Summary
Merges the useful parts of Silimate `.github/workflows/tests.yaml` into upstream `ci.yml` (instead of adding a second overlapping workflow).

**What this keeps**
- Existing native Ubuntu job (CUDD tarball, Ninja build, install artifacts, full `./regression`), renamed `linux-ubuntu`.
- Install artifact upload with upstream `retention-days: 1`, named `artifact-ubuntu`.

**What this adds**
- `linux-centos`: CentOS 7 via `docker build -f Dockerfile.centos7` (glibc/legacy coverage).
- `macos`: Brewfile-based native macOS build/test.

**What this intentionally drops from Silimate `tests.yaml`**
- Separate `tests.yaml` workflow (would double-run CI on every PR).
- Docker Ubuntu 22.04 / 24.04 jobs (redundant with native Ubuntu).
- `./regression -collections` fallback (collections is not part of upstream).
- Older `actions/checkout@v4` (kept upstream `@v7`).
- Separate `brew trust` CI step.
- Manual Dockerfile copy / `docker rm` / ignored `docker cp` return codes.

**Brew trust**
- Brewfile declares `brew "mht208/formal/cudd", trusted: true` so `brew bundle` applies formula-level trust. No extra CI step.

## Test plan
- [x] Confirm CI jobs: `linux-ubuntu`, `linux-centos`, `macos`
- [x] Confirm artifacts: `artifact-ubuntu`, `result-ubuntu`, `result-centos7`, `result-macos`
- [x] Confirm macOS installs CUDD via `brew bundle` alone