### PR TITLE
improve quality of life for messages check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -682,7 +682,7 @@ add_custom_target(sta_tags
 add_custom_command(
   TARGET OpenSTA
   POST_BUILD
-  COMMAND ${STA_HOME}/etc/FindMessages.tcl ${STA_HOME}/doc/Messages.md
+  COMMAND ${STA_HOME}/etc/FindMessages.tcl ${STA_HOME}/doc/Messages.md -lines_out ${CMAKE_CURRENT_BINARY_DIR}/Messages-lines.txt
   WORKING_DIRECTORY ${STA_HOME}
 )
 

--- a/doc/Messages.md
+++ b/doc/Messages.md
@@ -5,661 +5,661 @@ Do not edit it by hand; rebuild OpenSTA to regenerate.
 
 | ID | Location | Message |
 | --- | --- | --- |
-| 0100 | CmdArgs.tcl:116 | unsupported object type $object_type. |
-| 0101 | CmdArgs.tcl:173 | object '$obj' not found. |
-| 0102 | CmdArgs.tcl:428 | $scene_arg is not the name of a scene. |
-| 0103 | CmdArgs.tcl:434 | -scene keyword required with multi-scene analysis. |
-| 0104 | CmdArgs.tcl:455 | $scene_name is not the name of a scene. |
-| 0105 | CmdArgs.tcl:460 | missing -scene arg. |
-| 0106 | CmdArgs.tcl:478 | $scene_name is not the name of a scene. |
-| 0107 | CmdArgs.tcl:502 | $scene_name is not the name of a scene. |
-| 0108 | CmdArgs.tcl:587 | both -min and -max specified. |
-| 0109 | CmdArgs.tcl:601 | both -min and -max specified. |
-| 0110 | CmdArgs.tcl:628 | only one of -early and -late can be specified. |
-| 0111 | CmdArgs.tcl:634 | -early or -late must be specified. |
-| 0112 | CmdArgs.tcl:641 | both -early and -late specified. |
-| 0113 | CmdArgs.tcl:656 | $arg_name must be a single library. |
-| 0114 | CmdArgs.tcl:662 | $arg_name type '$object_type' is not a library. |
-| 0115 | CmdArgs.tcl:667 | library '$arg' not found. |
-| 0116 | CmdArgs.tcl:684 | $arg_name must be a single lib cell. |
-| 0123 | CmdArgs.tcl:771 | $arg_name must be a single instance. |
-| 0124 | CmdArgs.tcl:777 | $arg_name type '$object_type' is not an instance. |
-| 0125 | CmdArgs.tcl:782 | instance '$arg' not found. |
-| 0126 | CmdArgs.tcl:801 | $arg_name type '$object_type' is not an instance. |
-| 0127 | CmdArgs.tcl:808 | instance '$arg' not found. |
-| 0128 | CmdArgs.tcl:828 | $arg_name type '$object_type' is not a liberty cell. |
-| 0129 | CmdArgs.tcl:835 | liberty cell '$arg' not found. |
-| 0131 | CmdArgs.tcl:896 | $arg_name type '$object_type' is not a pin or port. |
-| 0132 | CmdArgs.tcl:903 | pin '$arg' not found. |
-| 0133 | CmdArgs.tcl:923 | $arg_name type '$object_type' is not a port. |
-| 0134 | CmdArgs.tcl:552 | $scene_arg is not the name of a scene. |
-| 0135 | CmdArgs.tcl:547 | scene object type '$object_type' is not a scene. |
-| 0139 | CmdArgs.tcl:1004 | unsupported object type $object_type. |
-| 0141 | CmdArgs.tcl:1025 | $arg_name '$object_type' is not a net. |
-| 0142 | CmdArgs.tcl:1049 | unsupported object type $object_type. |
-| 0143 | CmdArgs.tcl:1030 | $arg_name '$arg' not found. |
-| 0144 | CmdArgs.tcl:423 | scene object type '$object_type' is not a scene. |
-| 0160 | CmdUtil.tcl:61 | no commands match '$pattern'. |
-| 0161 | CmdUtil.tcl:217 | Usage: $cmd $cmd_args($cmd) |
-| 0162 | CmdUtil.tcl:219 | Usage: $cmd argument error |
-| 0164 | CmdUtil.tcl:400 | unsupported object type $list_type. |
-| 0165 | CmdUtil.tcl:418 | unknown namespace $namespc. |
-| 0166 | CmdUtil.tcl:344 | unknown unit $unit prefix '${arg_prefix}'. |
-| 0167 | CmdUtil.tcl:347 | incorrect unit suffix '$arg_suffix'. |
-| 0168 | Search.tcl:841 | unknown field $field. |
-| 0170 | SdfParse.yy:43 | {} |
-| 0171 | VerilogParse.yy:47 | {} |
-| 0172 | SdfReader.cc:310 | INSTANCE wildcards not supported. |
-| 0173 | SdfReader.cc:627 | NOCHANGE not supported. |
-| 0180 | SdfReader.cc:162 | TIMESCALE units not us, ns, or ps. |
-| 0181 | SdfReader.cc:165 | TIMESCALE multiplier not 1, 10, or 100. |
-| 0182 | SdfReader.cc:187 | pin {} is a hierarchical pin. |
-| 0183 | SdfReader.cc:189 | pin {} is a hierarchical pin. |
-| 0184 | SdfReader.cc:192 | INTERCONNECT from {} to {} not found. |
-| 0185 | SdfReader.cc:198 | pin {} not found. |
-| 0186 | SdfReader.cc:200 | pin {} not found. |
-| 0187 | SdfReader.cc:216 | pin {} not found. |
-| 0188 | SdfReader.cc:269 | {} with no triples. |
-| 0189 | SdfReader.cc:271 | {} with more than 2 triples. |
-| 0190 | SdfReader.cc:299 | instance {} cell {} does not match enclosing cell {}. |
-| 0191 | SdfReader.cc:383 | cell {} IOPATH {} -> {} not found. |
-| 0192 | SdfReader.cc:468 | cell {} {} -> {} {} check not found. |
-| 0193 | SdfReader.cc:290 | INSTANCE wildcards not supported. |
-| 0194 | SdfReader.cc:401 | instance {} port {} not found. |
-| 0195 | SdfReader.cc:977 | instance {} not found. |
-| 0196 | SdfReader.cc:1039 | {} |
-| 0204 | ArnoldiDelayCalc.cc:644 | arnoldi delay calc failed. |
-| 0220 | Link.tcl:53 | missing top_cell_name argument and no current_design. |
-| 0225 | InternalPower.cc:156 | unsupported table order |
-| 0226 | InternalPower.cc:171 | unsupported table axes |
-| 0230 | Network.tcl:59 | instance $instance_path not found. |
-| 0231 | Network.tcl:180 | net $net_path not found. |
-| 0232 | Network.tcl:183 | net $net_path not found. |
-| 0233 | Network.tcl:44 | report_instance -connections is deprecated. |
-| 0234 | Network.tcl:48 | report_instance -verbose is deprecated. |
-| 0239 | TableModel.cc:324 | unsupported table order |
-| 0240 | TableModel.cc:387 | unsupported table axes |
-| 0241 | TableModel.cc:634 | unsupported table order |
-| 0242 | TableModel.cc:652 | unsupported table axes |
-| 0243 | TimingArc.cc:252 | timing arc max index exceeded
+| 0100 | CmdArgs.tcl | unsupported object type $object_type. |
+| 0101 | CmdArgs.tcl | object '$obj' not found. |
+| 0102 | CmdArgs.tcl | $scene_arg is not the name of a scene. |
+| 0103 | CmdArgs.tcl | -scene keyword required with multi-scene analysis. |
+| 0104 | CmdArgs.tcl | $scene_name is not the name of a scene. |
+| 0105 | CmdArgs.tcl | missing -scene arg. |
+| 0106 | CmdArgs.tcl | $scene_name is not the name of a scene. |
+| 0107 | CmdArgs.tcl | $scene_name is not the name of a scene. |
+| 0108 | CmdArgs.tcl | both -min and -max specified. |
+| 0109 | CmdArgs.tcl | both -min and -max specified. |
+| 0110 | CmdArgs.tcl | only one of -early and -late can be specified. |
+| 0111 | CmdArgs.tcl | -early or -late must be specified. |
+| 0112 | CmdArgs.tcl | both -early and -late specified. |
+| 0113 | CmdArgs.tcl | $arg_name must be a single library. |
+| 0114 | CmdArgs.tcl | $arg_name type '$object_type' is not a library. |
+| 0115 | CmdArgs.tcl | library '$arg' not found. |
+| 0116 | CmdArgs.tcl | $arg_name must be a single lib cell. |
+| 0123 | CmdArgs.tcl | $arg_name must be a single instance. |
+| 0124 | CmdArgs.tcl | $arg_name type '$object_type' is not an instance. |
+| 0125 | CmdArgs.tcl | instance '$arg' not found. |
+| 0126 | CmdArgs.tcl | $arg_name type '$object_type' is not an instance. |
+| 0127 | CmdArgs.tcl | instance '$arg' not found. |
+| 0128 | CmdArgs.tcl | $arg_name type '$object_type' is not a liberty cell. |
+| 0129 | CmdArgs.tcl | liberty cell '$arg' not found. |
+| 0131 | CmdArgs.tcl | $arg_name type '$object_type' is not a pin or port. |
+| 0132 | CmdArgs.tcl | pin '$arg' not found. |
+| 0133 | CmdArgs.tcl | $arg_name type '$object_type' is not a port. |
+| 0134 | CmdArgs.tcl | $scene_arg is not the name of a scene. |
+| 0135 | CmdArgs.tcl | scene object type '$object_type' is not a scene. |
+| 0139 | CmdArgs.tcl | unsupported object type $object_type. |
+| 0141 | CmdArgs.tcl | $arg_name '$object_type' is not a net. |
+| 0142 | CmdArgs.tcl | unsupported object type $object_type. |
+| 0143 | CmdArgs.tcl | $arg_name '$arg' not found. |
+| 0144 | CmdArgs.tcl | scene object type '$object_type' is not a scene. |
+| 0160 | CmdUtil.tcl | no commands match '$pattern'. |
+| 0161 | CmdUtil.tcl | Usage: $cmd $cmd_args($cmd) |
+| 0162 | CmdUtil.tcl | Usage: $cmd argument error |
+| 0164 | CmdUtil.tcl | unsupported object type $list_type. |
+| 0165 | CmdUtil.tcl | unknown namespace $namespc. |
+| 0166 | CmdUtil.tcl | unknown unit $unit prefix '${arg_prefix}'. |
+| 0167 | CmdUtil.tcl | incorrect unit suffix '$arg_suffix'. |
+| 0168 | Search.tcl | unknown field $field. |
+| 0170 | SdfParse.yy | {} |
+| 0171 | VerilogParse.yy | {} |
+| 0172 | SdfReader.cc | INSTANCE wildcards not supported. |
+| 0173 | SdfReader.cc | NOCHANGE not supported. |
+| 0180 | SdfReader.cc | TIMESCALE units not us, ns, or ps. |
+| 0181 | SdfReader.cc | TIMESCALE multiplier not 1, 10, or 100. |
+| 0182 | SdfReader.cc | pin {} is a hierarchical pin. |
+| 0183 | SdfReader.cc | pin {} is a hierarchical pin. |
+| 0184 | SdfReader.cc | INTERCONNECT from {} to {} not found. |
+| 0185 | SdfReader.cc | pin {} not found. |
+| 0186 | SdfReader.cc | pin {} not found. |
+| 0187 | SdfReader.cc | pin {} not found. |
+| 0188 | SdfReader.cc | {} with no triples. |
+| 0189 | SdfReader.cc | {} with more than 2 triples. |
+| 0190 | SdfReader.cc | instance {} cell {} does not match enclosing cell {}. |
+| 0191 | SdfReader.cc | cell {} IOPATH {} -> {} not found. |
+| 0192 | SdfReader.cc | cell {} {} -> {} {} check not found. |
+| 0193 | SdfReader.cc | INSTANCE wildcards not supported. |
+| 0194 | SdfReader.cc | instance {} port {} not found. |
+| 0195 | SdfReader.cc | instance {} not found. |
+| 0196 | SdfReader.cc | {} |
+| 0204 | ArnoldiDelayCalc.cc | arnoldi delay calc failed. |
+| 0220 | Link.tcl | missing top_cell_name argument and no current_design. |
+| 0225 | InternalPower.cc | unsupported table order |
+| 0226 | InternalPower.cc | unsupported table axes |
+| 0230 | Network.tcl | instance $instance_path not found. |
+| 0231 | Network.tcl | net $net_path not found. |
+| 0232 | Network.tcl | net $net_path not found. |
+| 0233 | Network.tcl | report_instance -connections is deprecated. |
+| 0234 | Network.tcl | report_instance -verbose is deprecated. |
+| 0239 | TableModel.cc | unsupported table order |
+| 0240 | TableModel.cc | unsupported table axes |
+| 0241 | TableModel.cc | unsupported table order |
+| 0242 | TableModel.cc | unsupported table axes |
+| 0243 | TimingArc.cc | timing arc max index exceeded
  |
-| 0244 | Clock.cc:421 | generated clock edges size is not three. |
-| 0249 | GatedClk.cc:251 | illegal gated clock active value |
-| 0250 | NetworkEdit.tcl:135 | unsupported object type $object_type. |
-| 0252 | NetworkEdit.tcl:213 | unsupported object type $object_type. |
-| 0253 | NetworkEdit.tcl:235 | unsupported object type $object_type. |
-| 0266 | VertexVisitor.cc:40 | VertexPinCollector::copy not supported. |
-| 0268 | VerilogWriter.cc:263 | unknown port direction |
-| 0276 | Parasitics.tcl:93 | path instance '$path' not found. |
-| 0280 | PathEnum.cc:717 | diversion path not found |
-| 0303 | Power.tcl:256 | activity cannot be set on clock ports. |
-| 0304 | Power.tcl:72 | No liberty libraries have been read. |
-| 0305 | Power.tcl:292 | read_power_activities is deprecated. Use read_vcd. |
-| 0306 | Power.tcl:161 | Specify -activity or -density. |
-| 0307 | Power.tcl:173 | -activity requires a clock to be defined |
-| 0308 | Power.tcl:184 | -clock ignored for -density |
-| 0309 | Power.tcl:192 | duty should be 0.0 to 1.0 |
-| 0310 | Power.tcl:207 | activity cannot be set on clock ports. |
-| 0311 | Power.tcl:85 | unknown power report -format $format |
-| 0326 | Sdc.tcl:465 | object '$pattern' is not an instance. |
-| 0327 | Sdc.tcl:520 | object '$pattern' is not an clock. |
-| 0328 | Sdc.tcl:593 | object '$pattern' is not a liberty cell. |
-| 0329 | Sdc.tcl:690 | object '$pattern' is not a liberty pin. |
-| 0330 | Sdc.tcl:780 | object '$pattern' is not a liberty library. |
-| 0331 | Sdc.tcl:889 | object '$pattern' is not a net. |
-| 0332 | Sdc.tcl:991 | object '$pattern' is not a pin. |
-| 0333 | Sdc.tcl:1061 | object '$pattern' is not a port. |
-| 0334 | Sdc.tcl:3412 | object '$cell_name' is not a liberty cell. |
-| 0335 | Sdc.tcl:675 | positional arguments not supported with -of_objects. |
-| 0339 | Util.tcl:607 | tcl version > 8.6 required for zlib support. |
-| 0340 | Util.tcl:603 | cannot open '$filename'. |
-| 0341 | Util.tcl:654 | incomplete command at end of file. |
-| 0342 | Sdc.tcl:157 | hierarchy separator must be one of '$sdc_dividers'. |
-| 0343 | Sdc.tcl:224 | unknown unit $unit prefix '${arg_prefix}'. |
-| 0344 | Sdc.tcl:243 | unknown $unit prefix '$prefix'. |
-| 0345 | Sdc.tcl:249 | $unit scale [format %.0e $scale] does not match library scale [format %.0e $unit_scale]. |
-| 0346 | Sdc.tcl:345 | only one of -cells, -data_pins, -clock_pins, -async_pins, -output_pins are suppported. |
-| 0347 | Sdc.tcl:389 | current_design for other than top cell not supported. |
-| 0348 | Sdc.tcl:439 | patterns argument not supported with -of_objects. |
-| 0349 | Sdc.tcl:478 | instance '$pattern' not found. |
-| 0351 | Sdc.tcl:529 | clock '$pattern' not found. |
-| 0352 | Sdc.tcl:568 | positional arguments not supported with -of_objects. |
-| 0353 | Sdc.tcl:605 | library '$lib_name' not found. |
-| 0354 | Sdc.tcl:617 | cell '$cell_pattern' not found. |
-| 0355 | Sdc.tcl:703 | library/cell/port '$pattern' not found. |
-| 0356 | Sdc.tcl:726 | port '$port_pattern' not found. |
-| 0357 | Sdc.tcl:731 | library '$lib_name' not found. |
-| 0358 | Sdc.tcl:746 | -nocase ignored without -regexp. |
-| 0359 | Sdc.tcl:789 | library '$pattern' not found. |
-| 0360 | Sdc.tcl:870 | patterns argument not supported with -of_objects. |
-| 0361 | Sdc.tcl:900 | net '$pattern' not found. |
-| 0362 | Sdc.tcl:949 | patterns argument not supported with -of_objects. |
-| 0363 | Sdc.tcl:1007 | pin '$pattern' not found. |
-| 0365 | Sdc.tcl:1050 | patterns argument not supported with -of_objects. |
-| 0366 | Sdc.tcl:1070 | port '$pattern' not found. |
-| 0368 | Sdc.tcl:1138 | -add requires -name. |
-| 0369 | Sdc.tcl:1143 | -name or port_pin_list must be specified. |
-| 0370 | Sdc.tcl:1151 | missing -period argument. |
-| 0371 | Sdc.tcl:1157 | -waveform edge_list must have an even number of edge times. |
-| 0372 | Sdc.tcl:1166 | non-increasing clock -waveform edge times. |
-| 0373 | Sdc.tcl:1169 | -waveform time greater than two periods. |
-| 0374 | Sdc.tcl:1285 | empty ports/pins/nets argument. |
-| 0375 | Sdc.tcl:1293 | -add requires -name. |
-| 0376 | Sdc.tcl:1298 | name or port_pin_list must be specified. |
-| 0377 | Sdc.tcl:1305 | missing -source argument. |
-| 0378 | Sdc.tcl:1320 | -master_clock argument empty. |
-| 0379 | Sdc.tcl:1323 | -add requireds -master_clock. |
-| 0380 | Sdc.tcl:1327 | -multiply_by and -divide_by options are exclusive. |
-| 0381 | Sdc.tcl:1331 | -divide_by is not an integer greater than one. |
-| 0382 | Sdc.tcl:1334 | -combinational implies -divide_by 1. |
-| 0383 | Sdc.tcl:1339 | -multiply_by is not an integer greater than one. |
-| 0384 | Sdc.tcl:1345 | -duty_cycle is not a float between 0 and 100. |
-| 0385 | Sdc.tcl:1351 | -edges only supported for three edges. |
-| 0386 | Sdc.tcl:1357 | edges times are not monotonically increasing. |
-| 0387 | Sdc.tcl:1366 | -edge_shift length does not match -edges length. |
-| 0388 | Sdc.tcl:1372 | missing -multiply_by, -divide_by, -combinational or -edges argument. |
-| 0389 | Sdc.tcl:1380 | cannot specify -invert without -multiply_by, -divide_by or -combinational. |
-| 0390 | Sdc.tcl:1386 | -duty_cycle requires -multiply_by value. |
-| 0391 | Sdc.tcl:1467 | group_path command failed. |
-| 0392 | Sdc.tcl:1474 | positional arguments not supported. |
-| 0393 | Sdc.tcl:1478 | -from, -through or -to required. |
-| 0394 | Sdc.tcl:1484 | -name and -default are mutually exclusive. |
-| 0395 | Sdc.tcl:1486 | -name or -default option is required. |
-| 0396 | Sdc.tcl:1540 | cannot specify both -high and -low. |
-| 0397 | Sdc.tcl:1548 | missing -setup or -hold argument. |
-| 0398 | Sdc.tcl:1562 | -high and -low only permitted for pins and instances. |
-| 0399 | Sdc.tcl:1569 | -high and -low only permitted for pins and instances. |
-| 0400 | Sdc.tcl:1621 | one of -logically_exclusive, -physically_exclusive or -asynchronous is required. |
-| 0401 | Sdc.tcl:1624 | the keywords -logically_exclusive, -physically_exclusive and -asynchronous are mutually exclusive. |
-| 0402 | Sdc.tcl:1643 | unknown keyword argument $arg. |
-| 0403 | Sdc.tcl:1645 | extra positional argument $arg. |
-| 0404 | Sdc.tcl:1682 | the -all and -name options are mutually exclusive. |
-| 0405 | Sdc.tcl:1685 | either -all or -name options must be specified. |
-| 0406 | Sdc.tcl:1693 | one of -logically_exclusive, -physically_exclusive or -asynchronous is required. |
-| 0407 | Sdc.tcl:1696 | the keywords -logically_exclusive, -physically_exclusive and -asynchronous are mutually exclusive. |
-| 0408 | Sdc.tcl:1755 | -clock ignored for clock objects. |
-| 0409 | Sdc.tcl:1769 | -source '[get_full_name $pin]' is not a clock pin. |
-| 0410 | Sdc.tcl:1776 | -early/-late is only allowed with -source. |
-| 0411 | Sdc.tcl:1811 | -clock ignored for clock objects. |
-| 0412 | Sdc.tcl:1823 | -source '[$pin path_name]' is not a clock pin. |
-| 0413 | Sdc.tcl:1866 | set_sense -type data not supported. |
-| 0414 | Sdc.tcl:1870 | set_sense -type clock\|data |
-| 0415 | Sdc.tcl:1890 | set_clock_sense is deprecated as of SDC 2.1. Use set_sense -type clock. |
-| 0416 | Sdc.tcl:1902 | -pulse argument not supported. |
-| 0417 | Sdc.tcl:1911 | -positive, -negative, -stop_propagation and -pulse are mutually exclusive. |
-| 0418 | Sdc.tcl:1924 | hierarchical pin '[get_full_name $pin]' not supported. |
-| 0419 | Sdc.tcl:1953 | transition time can not be specified for virtual clocks. |
-| 0420 | Sdc.tcl:2014 | missing uncertainty value. |
-| 0421 | Sdc.tcl:2062 | -from/-to must be used together. |
-| 0422 | Sdc.tcl:2082 | -rise, -fall options not allowed for single clock uncertainty. |
-| 0423 | Sdc.tcl:2155 | -from/-to must be used together. |
-| 0424 | Sdc.tcl:2175 | -rise, -fall options not allowed for single clock uncertainty. |
-| 0425 | Sdc.tcl:2223 | missing -from, -rise_from or -fall_from argument. |
-| 0426 | Sdc.tcl:2235 | missing -to, -rise_to or -fall_to argument. |
-| 0427 | Sdc.tcl:2289 | missing -from, -rise_from or -fall_from argument. |
-| 0428 | Sdc.tcl:2301 | missing -to, -rise_to or -fall_to argument. |
-| 0429 | Sdc.tcl:2379 | -from/-to keywords ignored for lib_pin, port and pin arguments. |
-| 0430 | Sdc.tcl:2409 | -from/-to hierarchical instance not supported. |
-| 0431 | Sdc.tcl:2441 | pin '[get_full_name $inst]${hierarchy_separator}${port_name}' not found. |
-| 0432 | Sdc.tcl:2498 | pin '[get_name $cell]${hierarchy_separator}${port_name}' not found. |
-| 0434 | Sdc.tcl:2538 | -from/-to keywords ignored for lib_pin, port and pin arguments. |
-| 0435 | Sdc.tcl:2590 | -from/-to hierarchical instance not supported. |
-| 0436 | Sdc.tcl:2657 | '$args' ignored. |
-| 0437 | Sdc.tcl:2661 | -from, -through or -to required. |
-| 0438 | Sdc.tcl:2774 | -source_latency_included ignored with -reference_pin. |
-| 0439 | Sdc.tcl:2777 | -network_latency_included ignored with -reference_pin. |
-| 0440 | Sdc.tcl:2796 | $cmd not allowed on [pin_direction $pin] port '[get_full_name $pin]'. |
-| 0441 | Sdc.tcl:2798 | $cmd relative to a clock defined on the same port/pin not allowed. |
-| 0442 | Sdc.tcl:2866 | missing delay argument. |
-| 0443 | Sdc.tcl:2872 | '$args' ignored. |
-| 0444 | Sdc.tcl:3094 | missing path multiplier argument. |
-| 0445 | Sdc.tcl:3099 | '$args' ignored. |
-| 0446 | Sdc.tcl:3106 | cannot use -start with -end. |
-| 0447 | Sdc.tcl:3162 | $cmd command failed. |
-| 0448 | Sdc.tcl:3169 | positional arguments not supported. |
-| 0449 | Sdc.tcl:3173 | -from, -through or -to required. |
-| 0450 | Sdc.tcl:3263 | virtual clock [get_name $clk] can not be propagated. |
-| 0451 | Sdc.tcl:3315 | value must be 0, zero, 1, one, rise, rising, fall, or falling. |
-| 0452 | Sdc.tcl:3406 | cell '$lib_name:$cell_name' not found. |
-| 0453 | Sdc.tcl:3419 | '$cell_name' not found. |
-| 0454 | Sdc.tcl:3423 | missing -lib_cell argument. |
-| 0455 | Sdc.tcl:3431 | port '$to_port_name' not found. |
-| 0456 | Sdc.tcl:3443 | -pin argument required for cells with multiple outputs. |
-| 0457 | Sdc.tcl:3458 | port '$from_port_name' not found. |
-| 0458 | Sdc.tcl:3476 | -multiply_by ignored. |
-| 0459 | Sdc.tcl:3479 | -dont_scale ignored. |
-| 0460 | Sdc.tcl:3482 | -no_design_rule ignored. |
-| 0461 | Sdc.tcl:3506 | set_fanout_load not supported. |
-| 0462 | Sdc.tcl:3535 | -clock not supported. |
-| 0463 | Sdc.tcl:3538 | -clock_fall not supported. |
-| 0464 | Sdc.tcl:3608 | -pin_load not allowed for net objects. |
-| 0465 | Sdc.tcl:3611 | -wire_load not allowed for net objects. |
-| 0466 | Sdc.tcl:3614 | -rise/-fall not allowed for net objects. |
-| 0467 | Sdc.tcl:3722 | port '[get_name $port]' is not an input. |
-| 0468 | Sdc.tcl:3779 | -data_path, -clock_path, -rise, -fall ignored for ports and designs. |
-| 0469 | Sdc.tcl:3873 | derating factor greater than 2.0. |
-| 0470 | Sdc.tcl:3910 | -cell_delay and -cell_check flags ignored for net objects. |
-| 0471 | Sdc.tcl:3981 | no valid objects specified for $key. |
-| 0472 | Sdc.tcl:4014 | no valid objects specified for $key |
-| 0473 | Sdc.tcl:4063 | no valid objects specified for $key. |
-| 0474 | Sdc.tcl:4144 | operating condition '$op_cond_name' not found. |
-| 0475 | Sdc.tcl:4162 | operating condition '$op_cond_name' not found. |
-| 0476 | Sdc.tcl:4176 | -analysis_type must be single, bc_wc or on_chip_variation. |
-| 0477 | Sdc.tcl:4189 | set_wire_load_min_block_size not supported. |
-| 0478 | Sdc.tcl:4203 | mode must be top, enclosed or segmented. |
-| 0479 | Sdc.tcl:4224 | no wire load model specified. |
-| 0480 | Sdc.tcl:4246 | wire load model '$model_name' not found. |
-| 0481 | Sdc.tcl:4291 | wire load selection group '$selection_name' not found. |
-| 0482 | Sta.tcl:109 | define_corners must be called before read_liberty. |
-| 0483 | Sta.tcl:78 | -liberty or -liberty_min and -liberty_max are required arguments. |
-| 0484 | Sta.tcl:92 | -spef_min and -spef_max are required arguments. |
-| 0486 | Sdc.tcl:3593 | -subtract_pin_load not allowed for port objects. |
-| 0500 | Sdc.tcl:4472 | no default operating conditions found. |
-| 0501 | Sdc.tcl:227 | incorrect unit suffix '$arg_suffix'. |
-| 0502 | Search.tcl:209 | $cmd -endpoint_count is deprecated. Use -endpoint_path_count instead. |
-| 0503 | Search.tcl:222 | $cmd -group_count is deprecated. Use -group_path_count instead. |
-| 0510 | Search.tcl:183 | $cmd -path_delay must be min, min_rise, min_fall, max, max_rise, max_fall or min_max. |
-| 0511 | Search.tcl:193 | $cmd command failed. |
-| 0512 | Search.tcl:216 | -endpoint_path_count must be a positive integer. |
-| 0513 | Search.tcl:230 | -group_path_count must be >= 1. |
-| 0514 | Search.tcl:261 | '$arg' is not a known keyword or flag. |
-| 0515 | Search.tcl:263 | positional arguments not supported. |
-| 0516 | Search.tcl:299 | report_clock_skew -setup and -hold are mutually exclusive options. |
-| 0520 | Search.tcl:567 | analysis type single is not consistent with doing both setup/max and hold/min checks. |
-| 0521 | Search.tcl:573 | positional arguments not supported. |
-| 0522 | Search.tcl:738 | -min and -max cannot both be specified. |
-| 0523 | Search.tcl:758 | pin '$pin_arg' is hierarchical. |
-| 0524 | Search.tcl:811 | -format $format not recognized. |
-| 0526 | Search.tcl:1017 | specify one of -setup and -hold. |
-| 0527 | Search.tcl:1097 | unknown path group '$name'. |
-| 0540 | Sta.tcl:377 | -from/-to arguments not supported with -of_objects. |
-| 0541 | Sta.tcl:241 | No load pins connected to net [get_full_name $net]. |
-| 0560 | Util.tcl:52 | $cmd $key missing value. |
-| 0561 | Util.tcl:69 | $cmd $key missing value. |
-| 0562 | Util.tcl:79 | $cmd $arg is not a known keyword or flag. |
-| 0563 | Util.tcl:101 | $cmd $arg is not a known keyword or flag. |
-| 0564 | Util.tcl:481 | $cmd positional arguments not supported. |
-| 0565 | Util.tcl:487 | $cmd requires one positional argument. |
-| 0566 | Util.tcl:494 | $cmd requires zero or one positional arguments. |
-| 0567 | Util.tcl:500 | $cmd requires two positional arguments. |
-| 0568 | Util.tcl:507 | $cmd requires one or two positional arguments. |
-| 0569 | Util.tcl:513 | $cmd requires three positional arguments. |
-| 0570 | Util.tcl:519 | $cmd requires four positional arguments. |
-| 0571 | Util.tcl:527 | $cmd_arg '$arg' is not a float. |
-| 0572 | Util.tcl:533 | $cmd_arg '$arg' is not a positive float. |
-| 0573 | Util.tcl:539 | $cmd_arg '$arg' is not an integer. |
-| 0574 | Util.tcl:545 | $cmd_arg '$arg' is not a positive integer. |
-| 0575 | Util.tcl:551 | $cmd_arg '$arg' is not an integer greater than or equal to one. |
-| 0576 | Util.tcl:557 | $cmd_arg '$arg' is not between 0 and 100. |
-| 0577 | Sta.tcl:112 | define_corners must define at least one corner. |
-| 0578 | Sta.tcl:130 | $scene_name is not the name of a scene. |
-| 0579 | Sta.tcl:159 | $mode_name is not the name of a mode. |
-| 0590 | Variables.tcl:45 | sta_report_default_digits must be a positive integer. |
-| 0591 | Variables.tcl:70 | sta_crpr_mode must be pin or transition. |
-| 0592 | Variables.tcl:261 | $var_name value must be 0 or 1. |
-| 0593 | Variables.tcl:169 | sta_pocv_mode must be scalar, normal, or skew_normal. |
-| 0594 | Variables.tcl:187 | sta_pocv_quantile must be a positive floating point number. |
-| 0616 | Levelize.cc:516 | maximum logic level exceeded |
-| 0617 | Levelize.cc:666 | level check failed {} {} -> {} {} |
-| 0618 | Levelize.cc:647 | maximum logic level exceeded |
-| 0620 | Sdf.tcl:68 | -cond_use must be min, max or min_max. |
-| 0621 | Sdf.tcl:73 | -cond_use min_max cannot be used with analysis type single. |
-| 0623 | Sdf.tcl:245 | SDF -divider must be / or . |
-| 0624 | Sdf.tcl:130 | -list_annotated is deprecated. Use -report_annotated. |
-| 0626 | Sdf.tcl:203 | -list_annotated is deprecated. Use -report_annotated. |
-| 0627 | Sdf.tcl:209 | -list_not_annotated is deprecated. Use -report_unannotated. |
-| 0800 | VcdParse.cc:107 | unknown vcd command. |
-| 0801 | VcdParse.cc:141 | timescale syntax error. |
-| 0802 | VcdParse.cc:156 | Unknown timescale unit. |
-| 0804 | VcdParse.cc:203 | Variable syntax error. |
-| 0805 | VcdParse.cc:94 | invalid time {} |
-| 0806 | VcdParse.cc:97 | time out of range {} |
-| 0807 | VcdParse.cc:245 | unknown variable {} |
-| 0808 | VcdParse.cc:238 | unknown variable {} |
-| 0809 | VcdParse.cc:186 | Unknown variable type {}. |
-| 0820 | VcdReader.cc:445 | No clocks have been defined. |
-| 1000 | ConcreteNetwork.cc:2002 | cell type {} can not be linked. |
-| 1010 | CycleAccting.cc:96 | No common period was found between clocks {} and {}. |
-| 1040 | DmpCeff.cc:1020 | parasitic Pi model has NaNs. |
-| 1060 | Genclks.cc:242 | no master clock found for generated clock {}. |
-| 1100 | GraphDelayCalc.cc:591 | port not found in cell. |
-| 1101 | GraphDelayCalc.cc:913 | mult_drvr missing load. |
-| 1110 | Liberty.cc:749 | cell {}/{} port {} not found in cell {}/{}. |
-| 1111 | Liberty.cc:777 | cell {}/{} {} -> {} timing group {} not found in cell {}/{}. |
-| 1112 | Liberty.cc:796 | Liberty cell {}/{} for corner {}/{} not found. |
-| 1113 | Liberty.cc:1722 | cell {}/{} {} -> {} latch enable {}_edge is inconsistent with {} -> {} setup_{} check. |
-| 1114 | Liberty.cc:1658 | cell {}/{} {} -> {} latch enable {}_edge is inconsistent with latch group enable function positive sense. |
-| 1115 | Liberty.cc:1666 | cell {}/{} {} -> {} latch enable {}_edge is inconsistent with latch group enable function negative sense. |
-| 1116 | Liberty.cc:348 | unsupported slew degradation table axes |
-| 1117 | Liberty.cc:364 | unsupported slew degradation table axes |
-| 1118 | Liberty.cc:369 | unsupported slew degradation table order |
-| 1119 | Liberty.cc:399 | unsupported slew degradation table axes |
-| 1120 | Liberty.cc:1871 | library missing vdd |
-| 1121 | Liberty.cc:1676 | cell {}/{} no latch enable found for {} -> {}. |
-| 1128 | LibertyParser.cc:355 | LibertyAttrValue::floatValue() called on string |
-| 1130 | LibExprReader.cc:83 | {} references unknown port {}. |
-| 1131 | LibExprReader.cc:135 | {} {}. |
-| 1140 | LibertyReader.cc:280 | library {} already exists. |
-| 1141 | LibertyReader.cc:309 | library missing name. |
-| 1142 | LibertyReader.cc:832 | default_wire_load {} not found. |
-| 1143 | LibertyReader.cc:863 | default_wire_selection {} not found. |
-| 1144 | LibertyReader.cc:680 | default_operating_condition {} not found. |
-| 1145 | LibertyReader.cc:536 | input_threshold_pct_{} not found. |
-| 1146 | LibertyReader.cc:538 | output_threshold_pct_{} not found. |
-| 1147 | LibertyReader.cc:540 | slew_lower_threshold_pct_{} not found. |
-| 1148 | LibertyReader.cc:542 | slew_upper_threshold_pct_{} not found. |
-| 1150 | LibertyReader.cc:406 | unknown unit multiplier {}. |
-| 1151 | LibertyReader.cc:429 | unknown unit scale {}. |
-| 1152 | LibertyReader.cc:432 | unknown unit suffix {}. |
-| 1153 | LibertyReader.cc:435 | unknown unit suffix {}. |
-| 1154 | LibertyReader.cc:364 | capacitive_load_units are not ff or pf. |
-| 1155 | LibertyReader.cc:367 | capacitive_load_units are not a string. |
-| 1156 | LibertyReader.cc:373 | capacitive_load_units missing suffix. |
-| 1157 | LibertyReader.cc:370 | capacitive_load_units scale is not a float. |
-| 1158 | LibertyReader.cc:375 | capacitive_load_units missing scale and suffix. |
-| 1160 | LibertyReader.cc:453 | delay_model {} not supported. |
-| 1161 | LibertyReader.cc:457 | delay_model {} not supported. |
-| 1162 | LibertyReader.cc:461 | delay_model {} not supported. |
-| 1163 | LibertyReader.cc:466 | delay_model {} not supported.. |
-| 1164 | LibertyReader.cc:469 | unknown delay_model {}. |
-| 1165 | LibertyReader.cc:486 | unknown bus_naming_style format. |
-| 1166 | LibertyReader.cc:640 | voltage_map voltage is not a float. |
-| 1171 | LibertyReader.cc:962 | {} is 0.0. |
-| 1172 | LibertyReader.cc:964 | {} is 0.0. |
-| 1173 | LibertyReader.cc:2561 | non-increasing table index values. |
-| 1174 | LibertyReader.cc:847 | default_wire_load_mode {} not found. |
-| 1175 | LibertyReader.cc:577 | table template missing name. |
-| 1177 | LibertyReader.cc:2554 | missing table index values. |
-| 1178 | LibertyReader.cc:603 | non-increasing table index values. |
-| 1179 | LibertyReader.cc:508 | bus type missing bit_from. |
-| 1180 | LibertyReader.cc:510 | bus type missing bit_to. |
-| 1183 | LibertyReader.cc:3271 | {} value {} is not a float. |
-| 1184 | LibertyReader.cc:774 | wire_load missing name. |
-| 1185 | LibertyReader.cc:770 | fanout_length is missing length and fanout. |
-| 1187 | LibertyReader.cc:804 | wireload {} not found. |
-| 1189 | LibertyReader.cc:811 | wire_load_from_area min not a float. |
-| 1190 | LibertyReader.cc:814 | wire_load_from_area max not a float. |
-| 1191 | LibertyReader.cc:817 | wire_load_from_area missing parameters. |
-| 1193 | LibertyReader.cc:190 | cell missing name. |
-| 1196 | LibertyReader.cc:1723 | {} {} bus width mismatch. |
-| 1200 | LibertyReader.cc:2847 | latch enable function is non-unate for port {}. |
-| 1201 | LibertyReader.cc:2852 | latch enable function is unknown for port {}. |
-| 1202 | LibertyReader.cc:1021 | operating conditions {} not found. |
-| 1203 | LibertyReader.cc:1025 | scaled_cell missing operating condition. |
-| 1204 | LibertyReader.cc:1028 | scaled_cell cell {} has not been defined. |
-| 1205 | LibertyReader.cc:1031 | scaled_cell missing name. |
-| 1206 | LibertyReader.cc:1043 | scaled_cell {}, {} ports do not match cell ports |
-| 1207 | LibertyReader.cc:1053 | scaled_cell ports do not match cell ports. |
-| 1209 | LibertyReader.cc:1936 | combinational timing to an input port. |
-| 1210 | LibertyReader.cc:2184 | missing {}_transition. |
-| 1211 | LibertyReader.cc:2186 | missing cell_{}. |
-| 1212 | LibertyReader.cc:2592 | timing group from output port. |
-| 1213 | LibertyReader.cc:2602 | timing group from output port. |
-| 1214 | LibertyReader.cc:2612 | timing group from output port. |
-| 1215 | LibertyReader.cc:2647 | timing group from output port. |
-| 1219 | LibertyReader.cc:2362 | unsupported model axis. |
-| 1221 | LibertyReader.cc:2467 | output current waveform {:.2e} {:.2e} not found. |
-| 1224 | LibertyReader.cc:2415 | vector reference_time not found. |
-| 1227 | LibertyReader.cc:2895 | normalized_driver_waveform missing template. |
-| 1228 | LibertyReader.cc:2915 | level_shifter_type must be HL, LH, or HL_LH |
-| 1229 | LibertyReader.cc:2931 | switch_cell_type must be coarse_grain or fine_grain |
-| 1230 | LibertyReader.cc:1863 | scaling_factors {} not found. |
-| 1232 | LibertyReader.cc:1143 | pin {} not found. |
-| 1233 | LibertyReader.cc:1147 | pin name is not a string. |
-| 1234 | LibertyReader.cc:1197 | pin name is not a string. |
-| 1235 | LibertyReader.cc:1117 | bus_type {} not found. |
-| 1236 | LibertyReader.cc:1121 | bus_type not found. |
-| 1237 | LibertyReader.cc:2947 | OCV derate group named {} not found. |
-| 1238 | LibertyReader.cc:1376 | {} attribute is not boolean. |
-| 1239 | LibertyReader.cc:1379 | {} attribute is not boolean. |
-| 1240 | LibertyReader.cc:1491 | unknown port direction. |
-| 1241 | LibertyReader.cc:1551 | max_transition is 0.0. |
-| 1242 | LibertyReader.cc:1426 | pulse_latch unknown pulse type. |
-| 1243 | LibertyReader.cc:1956 | timing group missing related_pin/related_bus_pin. |
-| 1244 | LibertyReader.cc:2017 | unknown timing_type {}. |
-| 1245 | LibertyReader.cc:2003 | unknown timing_sense {}. |
-| 1246 | LibertyReader.cc:2074 | mode value is not a string. |
-| 1248 | LibertyReader.cc:2068 | mode name is not a string. |
-| 1249 | LibertyReader.cc:2077 | mode requirees 2 values. |
-| 1251 | LibertyReader.cc:2496 | unsupported model axis. |
-| 1253 | LibertyReader.cc:2502 | table template {} not found. |
-| 1254 | LibertyReader.cc:916 | unsupported model axis. |
-| 1256 | LibertyReader.cc:2871 | table template {} not found. |
-| 1257 | LibertyReader.cc:2541 | {} is missing values. |
-| 1258 | LibertyReader.cc:3194 | {} is not a list of floats. |
-| 1259 | LibertyReader.cc:3197 | {} row has {} columns but axis has {}. |
-| 1260 | LibertyReader.cc:3208 | {} missing axis values. |
-| 1261 | LibertyReader.cc:3211 | {} has {} rows but axis has {}. |
-| 1262 | LibertyReader.cc:3039 | cell {} test_cell redefinition. |
-| 1263 | LibertyReader.cc:896 | mode definition missing name. |
-| 1264 | LibertyReader.cc:892 | mode value missing name. |
-| 1272 | LibertyReader.cc:3240 | {} is not a float. |
-| 1273 | LibertyReader.cc:3245 | {} is not a float. |
-| 1274 | LibertyReader.cc:3248 | {} requires 2 valules. |
-| 1277 | LibertyReader.cc:3327 | {} has no values. |
-| 1279 | LibertyReader.cc:1908 | {} attribute is not boolean. |
-| 1280 | LibertyReader.cc:1911 | {} attribute is not boolean. |
-| 1282 | LibertyReader.cc:3370 | attribute {} value {} not recognized. |
-| 1283 | LibertyReader.cc:3386 | unknown early/late value. |
-| 1284 | LibertyReader.cc:3438 | OCV derate group named {} not found. |
-| 1285 | LibertyReader.cc:3524 | ocv_derate missing name. |
-| 1286 | LibertyReader.cc:3466 | unknown rise/fall. |
-| 1287 | LibertyReader.cc:3494 | unknown derate type. |
-| 1288 | LibertyReader.cc:3352 | {} attribute is not boolean. |
-| 1289 | LibertyReader.cc:3355 | {} attribute is not boolean. |
-| 1290 | LibertyReader.cc:2782 | port {} not found. |
-| 1291 | LibertyReader.cc:1232 | unknown pg_type. |
-| 1292 | LibertyReader.cc:3573 | port {} subscript out of range. |
-| 1293 | LibertyReader.cc:3576 | port range {} of non-bus port {}. |
-| 1294 | LibertyReader.cc:3590 | port {} not found. |
-| 1295 | LibertyReader.cc:3656 | port {} not found. |
-| 1297 | LibertyReader.cc:590 | axis type {} not supported. |
-| 1298 | LibertyReader.cc:3017 | statetable input port {} not found. |
-| 1299 | LibertyReader.cc:1464 | unknown signal_type {}. |
-| 1300 | LibertyReader.cc:2979 | table row must have 3 groups separated by ':'. |
-| 1301 | LibertyReader.cc:2984 | table row has {} input values but {} are required. |
-| 1303 | LibertyReader.cc:2997 | table row has {} next values but {} are required. |
-| 1304 | LibertyReader.cc:3147 | table input value '{}' not recognized. |
-| 1305 | LibertyReader.cc:3165 | table internal value '{}' not recognized. |
-| 1306 | LibertyReader.cc:2811 | port {} not found. |
-| 1307 | LibertyReader.cc:2702 | leakage_power missing value. |
-| 1308 | LibertyReader.cc:3517 | table template {} not found. |
-| 1309 | LibertyReader.cc:3480 | unknown early/late value. |
-| 1310 | LibertyReader.cc:3290 | {} is not a float. |
-| 1311 | LibertyReader.cc:2212 | no table models found in timing group. |
-| 1312 | LibertyReader.cc:3520 | ocv_derate_factors missing template. |
-| 1313 | LibertyReader.cc:1178 | bundle missing name. |
-| 1314 | LibertyReader.cc:1246 | pg_pin missing name. |
-| 1338 | Verilog.tcl:62 | The -sort flag is ignored. |
-| 1340 | LibertyWriter.cc:322 | {}/{} bundled ports not supported. |
-| 1341 | LibertyWriter.cc:482 | {}/{}/{} timing model not supported. |
-| 1342 | LibertyWriter.cc:500 | 3 axis table models not supported. |
-| 1343 | LibertyWriter.cc:647 | {}/{}/{} timing arc type {} not supported. |
-| 1350 | LumpedCapDelayCalc.cc:146 | gate delay load cap is NaN |
-| 1351 | LumpedCapDelayCalc.cc:148 | gate delay input slew is NaN |
-| 1360 | TagGroup.cc:314 | tag group missing tag |
-| 1370 | PathEnum.cc:634 | path diversion missing edge. |
-| 1380 | MakeTimingModel.cc:234 | clock {} pin {} is inside model block. |
-| 1390 | VerilogReader.cc:1492 | {} is not a verilog module. |
-| 1391 | VerilogReader.cc:1497 | {} is not a verilog module. |
-| 1440 | Bdd.cc:100 | unknown function operator |
-| 1450 | VcdReader.cc:454 | VCD max time is zero. |
-| 1451 | VcdReader.cc:299 | problem parsing bus {}. |
-| 1453 | VcdReader.cc:501 | clock {} pin {} has no vcd transitions. |
-| 1490 | Sdc.cc:4141 | group path name and is_default are mutually exclusive. |
-| 1510 | Search.cc:2686 | max tag group index exceeded |
-| 1511 | Search.cc:2931 | max tag index exceeded |
-| 1512 | Search.cc:3621 | unexpected filter path |
-| 1513 | Search.cc:3813 | tns incr existing vertex |
-| 1525 | SpefParse.yy:806 | {} is not positive. |
-| 1526 | SpefParse.yy:815 | {:.4f} is not positive. |
-| 1527 | SpefParse.yy:821 | {:.4f} is not positive. |
-| 1550 | Sta.cc:2171 | '{}' is not a valid start point. |
-| 1551 | Sta.cc:2230 | '{}' is not a valid endpoint. |
-| 1552 | Sta.cc:2233 | '{}' is not a valid endpoint. |
-| 1553 | Sta.cc:2591 | maximum scene count exceeded |
-| 1554 | Sta.cc:2168 | '{}' is not a valid start point. |
-| 1555 | Sta.cc:2739 | liberty name/filename {} not found. |
-| 1556 | Sta.cc:576 | multiple scenes reference mode {} |
-| 1557 | Sta.cc:4470 | net {} already exists. |
-| 1558 | Sta.cc:2624 | Spef file {} not found. |
-| 1559 | Sta.cc:2626 | Spef file {} not found. |
-| 1560 | Sta.cc:4264 | spef {} not found. |
-| 1561 | Sta.cc:2254 | mode {} not found. |
-| 1563 | Sta.cc:4599 | corresponding timing arc set not found in equiv cells |
-| 1570 | Sta.cc:3754 | No network has been linked. |
-| 1571 | Sta.cc:3763 | No network has been linked. |
-| 1572 | Sta.cc:2638 | mode {} not found. |
-| 1578 | Sta.cc:2388 | No liberty POCV/LVF models found. |
-| 1590 | Search.i:255 | {} is not a known path group name. |
-| 1591 | Search.i:472 | unknown report path field {} |
-| 1592 | Search.i:1009 | unknown common clk pessimism mode. |
-| 1601 | WriteSpice.cc:420 | pg_pin {}/{} voltage {} not found, |
-| 1602 | WriteSpice.cc:426 | Liberty pg_port {}/{} missing voltage_name attribute, |
-| 1603 | WriteSpice.cc:400 | {} pg_port {} not found, |
-| 1604 | WriteSpice.cc:863 | no register/latch found for path from {} to {}, |
-| 1605 | WriteSpice.cc:213 | The subkct file {} is missing definitions for {} |
-| 1606 | WritePathSpice.cc:236 | No instance with Liberty cell found in path. |
-| 1620 | WriteSdc.cc:1245 | unknown exception type |
-| 1621 | WriteSdc.cc:1784 | illegal set_logic value |
-| 1622 | WriteSdc.cc:1825 | invalid set_case_analysis value |
-| 1640 | SpefReader.cc:131 | illegal bus delimiters. |
-| 1641 | SpefReader.cc:188 | unknown units {}. |
-| 1642 | SpefReader.cc:200 | unknown units {}. |
-| 1643 | SpefReader.cc:212 | unknown units {}. |
-| 1644 | SpefReader.cc:226 | unknown units {}. |
-| 1645 | SpefReader.cc:247 | no name map entry for {}. |
-| 1646 | SpefReader.cc:266 | unknown port direction {}. |
-| 1647 | SpefReader.cc:292 | pin {}{}{} not found. |
-| 1648 | SpefReader.cc:296 | instance {}{}{} not found. |
-| 1649 | SpefReader.cc:303 | pin {} not found. |
-| 1650 | SpefReader.cc:317 | net {} not found. |
-| 1651 | SpefReader.cc:430 | {} not connected to net {}. |
-| 1652 | SpefReader.cc:435 | pin {}{}{} not found. |
-| 1653 | SpefReader.cc:445 | {}{}{} not connected to net {}. |
-| 1654 | SpefReader.cc:450 | node {}{}{} not a pin or net:number |
-| 1655 | SpefReader.cc:463 | {} not connected to net {}. |
-| 1656 | SpefReader.cc:468 | pin {} not found. |
-| 1657 | SpefReader.cc:471 | pin {} not found. |
-| 1658 | SpefReader.cc:589 | {} |
-| 1670 | SpefParse.yy:44 | {} |
-| 1700 | CcsCeffDelayCalc.cc:115 | VDD not defined in library {} |
-| 1701 | CcsCeffDelayCalc.cc:305 | unsupported ccs region count. |
-| 1751 | ArcDcalcWaveforms.cc:64 | VDD not defined in library {} |
-| 1752 | PrimaDelayCalc.cc:970 | G matrix is singular. |
-| 1754 | PrimaDelayCalc.cc:450 | Port {}/{}/{} has no equivalent in scene {}. |
-| 1800 | Sdc.tcl:2984 | missing margin argument. |
-| 1801 | Sdc.tcl:2986 | '$args' ignored. |
-| 1802 | Sdc.tcl:2990 | -from, -through or -to required. |
-| 1860 | SaifReader.cc:210 | {} |
-| 1861 | SaifReader.cc:104 | SAIF TIMESCALE units not us, ns, or ps. |
-| 1862 | SaifReader.cc:107 | SAIF TIMESCALE multiplier not 1, 10, or 100. |
-| 1866 | LibertyParser.cc:295 | {} |
-| 1870 | VerilogReader.cc:1963 | {} |
-| 1903 | WriteSpice.tcl:180 | Cannot write $spice_dir. |
-| 1904 | WriteSpice.tcl:183 | No -spice_filename specified. |
-| 1905 | WriteSpice.tcl:189 | -lib_subckt_file $lib_subckt_file is not readable. |
-| 1906 | WriteSpice.tcl:192 | No -lib_subckt_file specified. |
-| 1907 | WriteSpice.tcl:198 | -model_file $model_file is not readable. |
-| 1908 | WriteSpice.tcl:201 | No -model_file specified. |
-| 1909 | WriteSpice.tcl:207 | No -power specified. |
-| 1910 | WriteSpice.tcl:146 | Unknown circuit simulator |
-| 1913 | WriteSpice.tcl:279 | Cannot write $plot_dir. |
-| 1914 | WriteSpice.tcl:282 | No -plot_basename specified. |
-| 1915 | WriteSpice.tcl:213 | No -ground specified. |
-| 1920 | WriteSpice.tcl:71 | Directory $spice_dir not found. |
-| 1921 | WriteSpice.tcl:74 | $spice_dir is not a directory. |
-| 1922 | WriteSpice.tcl:77 | Cannot write in $spice_dir. |
-| 1923 | WriteSpice.tcl:80 | No -spice_file specified. |
-| 1924 | WriteSpice.tcl:86 | -lib_subckt_file $lib_subckt_file is not readable. |
-| 1925 | WriteSpice.tcl:89 | No -lib_subckt_file specified. |
-| 1926 | WriteSpice.tcl:95 | -model_file $model_file is not readable. |
-| 1927 | WriteSpice.tcl:98 | No -model_file specified. |
-| 1928 | WriteSpice.tcl:104 | No -power specified. |
-| 1929 | WriteSpice.tcl:110 | No -ground specified. |
-| 1930 | WriteSpice.tcl:116 | No -path_args specified. |
-| 1931 | WriteSpice.tcl:121 | No paths found for -path_args $path_args. |
-| 1932 | WriteSpice.tcl:174 | Missing -gates argument. |
-| 1933 | WriteSpice.tcl:247 | Missing -gates argument. |
-| 2100 | ArcDelayCalc.cc:101 | no timing arc for {} input/driver pins. |
-| 2101 | ArcDelayCalc.cc:106 | {} not a valid rise/fall. |
-| 2102 | ArcDelayCalc.cc:109 | Pin {}/{} not found. |
-| 2103 | ArcDelayCalc.cc:112 | {} not a valid rise/fall. |
-| 2104 | ArcDelayCalc.cc:115 | Pin {}/{} not found. |
-| 2105 | ArcDelayCalc.cc:118 | Instance {} not found. |
-| 2120 | Network.i:267 | unknown namespace |
-| 2121 | Sdc.i:121 | unknown analysis type |
-| 2122 | Sdc.i:260 | unknown wire load mode |
-| 2123 | Sdc.i:1065 | unknown clock sense |
-| 2140 | TclTypeHelpers.cc:166 | Delay calc arg requires 5 or 6 args. |
-| 2141 | Sta.cc:3767 | No liberty libraries found. |
-| 2150 | StaTclTypes.i:423 | Unknown transition '{}'. |
-| 2151 | StaTclTypes.i:441 | Unknown rise/fall edge '{}'. |
-| 2152 | StaTclTypes.i:459 | Unknown transition name '{}'. |
-| 2153 | StaTclTypes.i:477 | Unknown port direction '{}'. |
-| 2154 | StaTclTypes.i:492 | Unknown timing role '{}'. |
-| 2155 | StaTclTypes.i:515 | Unknown logic value '{}'. |
-| 2156 | StaTclTypes.i:530 | Unknown analysis type '{}'. |
-| 2157 | StaTclTypes.i:735 | {} is not a floating point number. |
-| 2158 | StaTclTypes.i:797 | {} is not an integer. |
-| 2159 | StaTclTypes.i:859 | {} not min or max. |
-| 2160 | StaTclTypes.i:880 | {} not min, max or min_max. |
-| 2161 | StaTclTypes.i:896 | {} not min, max or min_max. |
-| 2162 | StaTclTypes.i:918 | {} not setup, hold, min or max. |
-| 2163 | StaTclTypes.i:938 | {} not setup, hold, setup_hold, min, max or min_max. |
-| 2164 | StaTclTypes.i:953 | {} not early/min, late/max or early_late/min_max. |
-| 2165 | StaTclTypes.i:967 | {} not early/min, late/max or early_late/min_max. |
-| 2166 | StaTclTypes.i:982 | {} not net_delay, cell_delay or cell_check. |
-| 2167 | StaTclTypes.i:995 | {} not cell_delay or cell_check. |
-| 2168 | StaTclTypes.i:1008 | {} not clk or data. |
-| 2169 | StaTclTypes.i:1021 | {} not group or slack. |
-| 2170 | StaTclTypes.i:1046 | unknown path type {}. |
-| 2171 | StaTclTypes.i:1413 | unknown circuit simulator {}. |
-| 2173 | StaTclTypes.i:1237 | {} is not a scene object. |
-| 2174 | StaTclTypes.i:1200 | {} is not a mode object. |
-| 2175 | StaTclTypes.i:767 | {} is not a floating point number. |
-| 2200 | Property.tcl:62 | get_property object is null. |
-| 2201 | Property.tcl:67 | get_property -object_type must be specified with object name argument. |
-| 2203 | Property.tcl:111 | get_property unsupported object type $object_type. |
-| 2204 | Property.tcl:114 | get_property $object is not an object. |
-| 2205 | Property.tcl:141 | $object_type not supported. |
-| 2206 | Property.tcl:144 | $object_type '$object_name' not found. |
-| 2207 | Property.tcl:162 | define_property -object_type must be specified. |
-| 2208 | Property.tcl:165 | define_property -type must be specified. |
-| 2209 | Property.i:173 | define_property -object_type {} not supported. |
-| 2210 | Property.cc:1415 | unknown property type '{}' (use bool, float or string). |
-| 2211 | Property.cc:1532 | {} property '{}' is not defined. |
-| 2212 | Property.cc:1430 | '{}' is not a bool property value. |
-| 2213 | Property.tcl:184 | set_property $object is not an object. |
-| 2214 | Property.i:210 | set_property unsupported object type {}. |
-| 2215 | Property.cc:1435 | '{}' is not a float property value. |
-| 2300 | Bfs.cc:264 | vertex {} level {} != bfs level {} |
-| 2400 | Power.cc:835 | unknown cudd constant |
-| 2500 | DelayCalc.tcl:140 | delay calculator $alg not found. |
-| 2501 | DelayCalc.tcl:172 | set_assigned_delay missing -from argument. |
-| 2502 | DelayCalc.tcl:177 | set_assigned_delay missing -to argument. |
-| 2503 | DelayCalc.tcl:182 | set_assigned_delay delay is not a float. |
-| 2504 | DelayCalc.tcl:187 | set_annotated_delay -cell and -net options are mutually excluive. |
-| 2505 | DelayCalc.tcl:193 | set_assigned_delay pin [get_full_name $pin] is not attached to instance [get_full_name $inst]. |
-| 2506 | DelayCalc.tcl:198 | set_assigned_delay pin [get_full_name $pin] is not attached to instance [get_full_name $inst] |
-| 2508 | DelayCalc.tcl:203 | set_assigned_delay -cell or -net required. |
-| 2509 | DelayCalc.tcl:247 | set_assigned_delay no timing arcs found between from/to pins. |
-| 2510 | DelayCalc.tcl:279 | set_assigned_check missing -from argument. |
-| 2511 | DelayCalc.tcl:288 | set_assigned_check -clock must be rise or fall. |
-| 2512 | DelayCalc.tcl:295 | set_assigned_check missing -to argument. |
-| 2513 | DelayCalc.tcl:310 | set_assigned_check missing -setup\|-hold\|-recovery\|-removal check type.. |
-| 2514 | DelayCalc.tcl:318 | set_assigned_check check_value is not a float. |
-| 2516 | DelayCalc.tcl:370 | set_assigned_check no check arcs found between from/to pins. |
-| 2518 | DelayCalc.tcl:397 | set_assigned_transition transition is not a float. |
-| 2600 | FilterObjects.cc:195 | -filter parsing failed at '{}'. |
-| 2601 | FilterObjects.cc:238 | -filter extraneous ). |
-| 2602 | FilterObjects.cc:244 | -filter extraneous ). |
-| 2603 | FilterObjects.cc:257 | -filter unmatched (. |
-| 2604 | FilterObjects.cc:323 | -filter logical OR requires at least two operands. |
-| 2605 | FilterObjects.cc:335 | -filter logical AND requires two operands. |
-| 2606 | FilterObjects.cc:350 | -filter NOT missing operand. |
-| 2607 | FilterObjects.cc:423 | -filter expression is empty. |
-| 2608 | FilterObjects.cc:426 | -filter expression evaluated to multiple sets. |
-| 2700 | ConcreteParasitics.cc:981 | piModel called on non-PiElmore parasitic. |
-| 2701 | ConcreteParasitics.cc:994 | setPiModel called on non-PiElmore parasitic. |
-| 2720 | ReportPath.cc:257 | unknown path reporting field {}. |
+| 0244 | Clock.cc | generated clock edges size is not three. |
+| 0249 | GatedClk.cc | illegal gated clock active value |
+| 0250 | NetworkEdit.tcl | unsupported object type $object_type. |
+| 0252 | NetworkEdit.tcl | unsupported object type $object_type. |
+| 0253 | NetworkEdit.tcl | unsupported object type $object_type. |
+| 0266 | VertexVisitor.cc | VertexPinCollector::copy not supported. |
+| 0268 | VerilogWriter.cc | unknown port direction |
+| 0276 | Parasitics.tcl | path instance '$path' not found. |
+| 0280 | PathEnum.cc | diversion path not found |
+| 0303 | Power.tcl | activity cannot be set on clock ports. |
+| 0304 | Power.tcl | No liberty libraries have been read. |
+| 0305 | Power.tcl | read_power_activities is deprecated. Use read_vcd. |
+| 0306 | Power.tcl | Specify -activity or -density. |
+| 0307 | Power.tcl | -activity requires a clock to be defined |
+| 0308 | Power.tcl | -clock ignored for -density |
+| 0309 | Power.tcl | duty should be 0.0 to 1.0 |
+| 0310 | Power.tcl | activity cannot be set on clock ports. |
+| 0311 | Power.tcl | unknown power report -format $format |
+| 0326 | Sdc.tcl | object '$pattern' is not an instance. |
+| 0327 | Sdc.tcl | object '$pattern' is not an clock. |
+| 0328 | Sdc.tcl | object '$pattern' is not a liberty cell. |
+| 0329 | Sdc.tcl | object '$pattern' is not a liberty pin. |
+| 0330 | Sdc.tcl | object '$pattern' is not a liberty library. |
+| 0331 | Sdc.tcl | object '$pattern' is not a net. |
+| 0332 | Sdc.tcl | object '$pattern' is not a pin. |
+| 0333 | Sdc.tcl | object '$pattern' is not a port. |
+| 0334 | Sdc.tcl | object '$cell_name' is not a liberty cell. |
+| 0335 | Sdc.tcl | positional arguments not supported with -of_objects. |
+| 0339 | Util.tcl | tcl version > 8.6 required for zlib support. |
+| 0340 | Util.tcl | cannot open '$filename'. |
+| 0341 | Util.tcl | incomplete command at end of file. |
+| 0342 | Sdc.tcl | hierarchy separator must be one of '$sdc_dividers'. |
+| 0343 | Sdc.tcl | unknown unit $unit prefix '${arg_prefix}'. |
+| 0344 | Sdc.tcl | unknown $unit prefix '$prefix'. |
+| 0345 | Sdc.tcl | $unit scale [format %.0e $scale] does not match library scale [format %.0e $unit_scale]. |
+| 0346 | Sdc.tcl | only one of -cells, -data_pins, -clock_pins, -async_pins, -output_pins are suppported. |
+| 0347 | Sdc.tcl | current_design for other than top cell not supported. |
+| 0348 | Sdc.tcl | patterns argument not supported with -of_objects. |
+| 0349 | Sdc.tcl | instance '$pattern' not found. |
+| 0351 | Sdc.tcl | clock '$pattern' not found. |
+| 0352 | Sdc.tcl | positional arguments not supported with -of_objects. |
+| 0353 | Sdc.tcl | library '$lib_name' not found. |
+| 0354 | Sdc.tcl | cell '$cell_pattern' not found. |
+| 0355 | Sdc.tcl | library/cell/port '$pattern' not found. |
+| 0356 | Sdc.tcl | port '$port_pattern' not found. |
+| 0357 | Sdc.tcl | library '$lib_name' not found. |
+| 0358 | Sdc.tcl | -nocase ignored without -regexp. |
+| 0359 | Sdc.tcl | library '$pattern' not found. |
+| 0360 | Sdc.tcl | patterns argument not supported with -of_objects. |
+| 0361 | Sdc.tcl | net '$pattern' not found. |
+| 0362 | Sdc.tcl | patterns argument not supported with -of_objects. |
+| 0363 | Sdc.tcl | pin '$pattern' not found. |
+| 0365 | Sdc.tcl | patterns argument not supported with -of_objects. |
+| 0366 | Sdc.tcl | port '$pattern' not found. |
+| 0368 | Sdc.tcl | -add requires -name. |
+| 0369 | Sdc.tcl | -name or port_pin_list must be specified. |
+| 0370 | Sdc.tcl | missing -period argument. |
+| 0371 | Sdc.tcl | -waveform edge_list must have an even number of edge times. |
+| 0372 | Sdc.tcl | non-increasing clock -waveform edge times. |
+| 0373 | Sdc.tcl | -waveform time greater than two periods. |
+| 0374 | Sdc.tcl | empty ports/pins/nets argument. |
+| 0375 | Sdc.tcl | -add requires -name. |
+| 0376 | Sdc.tcl | name or port_pin_list must be specified. |
+| 0377 | Sdc.tcl | missing -source argument. |
+| 0378 | Sdc.tcl | -master_clock argument empty. |
+| 0379 | Sdc.tcl | -add requireds -master_clock. |
+| 0380 | Sdc.tcl | -multiply_by and -divide_by options are exclusive. |
+| 0381 | Sdc.tcl | -divide_by is not an integer greater than one. |
+| 0382 | Sdc.tcl | -combinational implies -divide_by 1. |
+| 0383 | Sdc.tcl | -multiply_by is not an integer greater than one. |
+| 0384 | Sdc.tcl | -duty_cycle is not a float between 0 and 100. |
+| 0385 | Sdc.tcl | -edges only supported for three edges. |
+| 0386 | Sdc.tcl | edges times are not monotonically increasing. |
+| 0387 | Sdc.tcl | -edge_shift length does not match -edges length. |
+| 0388 | Sdc.tcl | missing -multiply_by, -divide_by, -combinational or -edges argument. |
+| 0389 | Sdc.tcl | cannot specify -invert without -multiply_by, -divide_by or -combinational. |
+| 0390 | Sdc.tcl | -duty_cycle requires -multiply_by value. |
+| 0391 | Sdc.tcl | group_path command failed. |
+| 0392 | Sdc.tcl | positional arguments not supported. |
+| 0393 | Sdc.tcl | -from, -through or -to required. |
+| 0394 | Sdc.tcl | -name and -default are mutually exclusive. |
+| 0395 | Sdc.tcl | -name or -default option is required. |
+| 0396 | Sdc.tcl | cannot specify both -high and -low. |
+| 0397 | Sdc.tcl | missing -setup or -hold argument. |
+| 0398 | Sdc.tcl | -high and -low only permitted for pins and instances. |
+| 0399 | Sdc.tcl | -high and -low only permitted for pins and instances. |
+| 0400 | Sdc.tcl | one of -logically_exclusive, -physically_exclusive or -asynchronous is required. |
+| 0401 | Sdc.tcl | the keywords -logically_exclusive, -physically_exclusive and -asynchronous are mutually exclusive. |
+| 0402 | Sdc.tcl | unknown keyword argument $arg. |
+| 0403 | Sdc.tcl | extra positional argument $arg. |
+| 0404 | Sdc.tcl | the -all and -name options are mutually exclusive. |
+| 0405 | Sdc.tcl | either -all or -name options must be specified. |
+| 0406 | Sdc.tcl | one of -logically_exclusive, -physically_exclusive or -asynchronous is required. |
+| 0407 | Sdc.tcl | the keywords -logically_exclusive, -physically_exclusive and -asynchronous are mutually exclusive. |
+| 0408 | Sdc.tcl | -clock ignored for clock objects. |
+| 0409 | Sdc.tcl | -source '[get_full_name $pin]' is not a clock pin. |
+| 0410 | Sdc.tcl | -early/-late is only allowed with -source. |
+| 0411 | Sdc.tcl | -clock ignored for clock objects. |
+| 0412 | Sdc.tcl | -source '[$pin path_name]' is not a clock pin. |
+| 0413 | Sdc.tcl | set_sense -type data not supported. |
+| 0414 | Sdc.tcl | set_sense -type clock\|data |
+| 0415 | Sdc.tcl | set_clock_sense is deprecated as of SDC 2.1. Use set_sense -type clock. |
+| 0416 | Sdc.tcl | -pulse argument not supported. |
+| 0417 | Sdc.tcl | -positive, -negative, -stop_propagation and -pulse are mutually exclusive. |
+| 0418 | Sdc.tcl | hierarchical pin '[get_full_name $pin]' not supported. |
+| 0419 | Sdc.tcl | transition time can not be specified for virtual clocks. |
+| 0420 | Sdc.tcl | missing uncertainty value. |
+| 0421 | Sdc.tcl | -from/-to must be used together. |
+| 0422 | Sdc.tcl | -rise, -fall options not allowed for single clock uncertainty. |
+| 0423 | Sdc.tcl | -from/-to must be used together. |
+| 0424 | Sdc.tcl | -rise, -fall options not allowed for single clock uncertainty. |
+| 0425 | Sdc.tcl | missing -from, -rise_from or -fall_from argument. |
+| 0426 | Sdc.tcl | missing -to, -rise_to or -fall_to argument. |
+| 0427 | Sdc.tcl | missing -from, -rise_from or -fall_from argument. |
+| 0428 | Sdc.tcl | missing -to, -rise_to or -fall_to argument. |
+| 0429 | Sdc.tcl | -from/-to keywords ignored for lib_pin, port and pin arguments. |
+| 0430 | Sdc.tcl | -from/-to hierarchical instance not supported. |
+| 0431 | Sdc.tcl | pin '[get_full_name $inst]${hierarchy_separator}${port_name}' not found. |
+| 0432 | Sdc.tcl | pin '[get_name $cell]${hierarchy_separator}${port_name}' not found. |
+| 0434 | Sdc.tcl | -from/-to keywords ignored for lib_pin, port and pin arguments. |
+| 0435 | Sdc.tcl | -from/-to hierarchical instance not supported. |
+| 0436 | Sdc.tcl | '$args' ignored. |
+| 0437 | Sdc.tcl | -from, -through or -to required. |
+| 0438 | Sdc.tcl | -source_latency_included ignored with -reference_pin. |
+| 0439 | Sdc.tcl | -network_latency_included ignored with -reference_pin. |
+| 0440 | Sdc.tcl | $cmd not allowed on [pin_direction $pin] port '[get_full_name $pin]'. |
+| 0441 | Sdc.tcl | $cmd relative to a clock defined on the same port/pin not allowed. |
+| 0442 | Sdc.tcl | missing delay argument. |
+| 0443 | Sdc.tcl | '$args' ignored. |
+| 0444 | Sdc.tcl | missing path multiplier argument. |
+| 0445 | Sdc.tcl | '$args' ignored. |
+| 0446 | Sdc.tcl | cannot use -start with -end. |
+| 0447 | Sdc.tcl | $cmd command failed. |
+| 0448 | Sdc.tcl | positional arguments not supported. |
+| 0449 | Sdc.tcl | -from, -through or -to required. |
+| 0450 | Sdc.tcl | virtual clock [get_name $clk] can not be propagated. |
+| 0451 | Sdc.tcl | value must be 0, zero, 1, one, rise, rising, fall, or falling. |
+| 0452 | Sdc.tcl | cell '$lib_name:$cell_name' not found. |
+| 0453 | Sdc.tcl | '$cell_name' not found. |
+| 0454 | Sdc.tcl | missing -lib_cell argument. |
+| 0455 | Sdc.tcl | port '$to_port_name' not found. |
+| 0456 | Sdc.tcl | -pin argument required for cells with multiple outputs. |
+| 0457 | Sdc.tcl | port '$from_port_name' not found. |
+| 0458 | Sdc.tcl | -multiply_by ignored. |
+| 0459 | Sdc.tcl | -dont_scale ignored. |
+| 0460 | Sdc.tcl | -no_design_rule ignored. |
+| 0461 | Sdc.tcl | set_fanout_load not supported. |
+| 0462 | Sdc.tcl | -clock not supported. |
+| 0463 | Sdc.tcl | -clock_fall not supported. |
+| 0464 | Sdc.tcl | -pin_load not allowed for net objects. |
+| 0465 | Sdc.tcl | -wire_load not allowed for net objects. |
+| 0466 | Sdc.tcl | -rise/-fall not allowed for net objects. |
+| 0467 | Sdc.tcl | port '[get_name $port]' is not an input. |
+| 0468 | Sdc.tcl | -data_path, -clock_path, -rise, -fall ignored for ports and designs. |
+| 0469 | Sdc.tcl | derating factor greater than 2.0. |
+| 0470 | Sdc.tcl | -cell_delay and -cell_check flags ignored for net objects. |
+| 0471 | Sdc.tcl | no valid objects specified for $key. |
+| 0472 | Sdc.tcl | no valid objects specified for $key |
+| 0473 | Sdc.tcl | no valid objects specified for $key. |
+| 0474 | Sdc.tcl | operating condition '$op_cond_name' not found. |
+| 0475 | Sdc.tcl | operating condition '$op_cond_name' not found. |
+| 0476 | Sdc.tcl | -analysis_type must be single, bc_wc or on_chip_variation. |
+| 0477 | Sdc.tcl | set_wire_load_min_block_size not supported. |
+| 0478 | Sdc.tcl | mode must be top, enclosed or segmented. |
+| 0479 | Sdc.tcl | no wire load model specified. |
+| 0480 | Sdc.tcl | wire load model '$model_name' not found. |
+| 0481 | Sdc.tcl | wire load selection group '$selection_name' not found. |
+| 0482 | Sta.tcl | define_corners must be called before read_liberty. |
+| 0483 | Sta.tcl | -liberty or -liberty_min and -liberty_max are required arguments. |
+| 0484 | Sta.tcl | -spef_min and -spef_max are required arguments. |
+| 0486 | Sdc.tcl | -subtract_pin_load not allowed for port objects. |
+| 0500 | Sdc.tcl | no default operating conditions found. |
+| 0501 | Sdc.tcl | incorrect unit suffix '$arg_suffix'. |
+| 0502 | Search.tcl | $cmd -endpoint_count is deprecated. Use -endpoint_path_count instead. |
+| 0503 | Search.tcl | $cmd -group_count is deprecated. Use -group_path_count instead. |
+| 0510 | Search.tcl | $cmd -path_delay must be min, min_rise, min_fall, max, max_rise, max_fall or min_max. |
+| 0511 | Search.tcl | $cmd command failed. |
+| 0512 | Search.tcl | -endpoint_path_count must be a positive integer. |
+| 0513 | Search.tcl | -group_path_count must be >= 1. |
+| 0514 | Search.tcl | '$arg' is not a known keyword or flag. |
+| 0515 | Search.tcl | positional arguments not supported. |
+| 0516 | Search.tcl | report_clock_skew -setup and -hold are mutually exclusive options. |
+| 0520 | Search.tcl | analysis type single is not consistent with doing both setup/max and hold/min checks. |
+| 0521 | Search.tcl | positional arguments not supported. |
+| 0522 | Search.tcl | -min and -max cannot both be specified. |
+| 0523 | Search.tcl | pin '$pin_arg' is hierarchical. |
+| 0524 | Search.tcl | -format $format not recognized. |
+| 0526 | Search.tcl | specify one of -setup and -hold. |
+| 0527 | Search.tcl | unknown path group '$name'. |
+| 0540 | Sta.tcl | -from/-to arguments not supported with -of_objects. |
+| 0541 | Sta.tcl | No load pins connected to net [get_full_name $net]. |
+| 0560 | Util.tcl | $cmd $key missing value. |
+| 0561 | Util.tcl | $cmd $key missing value. |
+| 0562 | Util.tcl | $cmd $arg is not a known keyword or flag. |
+| 0563 | Util.tcl | $cmd $arg is not a known keyword or flag. |
+| 0564 | Util.tcl | $cmd positional arguments not supported. |
+| 0565 | Util.tcl | $cmd requires one positional argument. |
+| 0566 | Util.tcl | $cmd requires zero or one positional arguments. |
+| 0567 | Util.tcl | $cmd requires two positional arguments. |
+| 0568 | Util.tcl | $cmd requires one or two positional arguments. |
+| 0569 | Util.tcl | $cmd requires three positional arguments. |
+| 0570 | Util.tcl | $cmd requires four positional arguments. |
+| 0571 | Util.tcl | $cmd_arg '$arg' is not a float. |
+| 0572 | Util.tcl | $cmd_arg '$arg' is not a positive float. |
+| 0573 | Util.tcl | $cmd_arg '$arg' is not an integer. |
+| 0574 | Util.tcl | $cmd_arg '$arg' is not a positive integer. |
+| 0575 | Util.tcl | $cmd_arg '$arg' is not an integer greater than or equal to one. |
+| 0576 | Util.tcl | $cmd_arg '$arg' is not between 0 and 100. |
+| 0577 | Sta.tcl | define_corners must define at least one corner. |
+| 0578 | Sta.tcl | $scene_name is not the name of a scene. |
+| 0579 | Sta.tcl | $mode_name is not the name of a mode. |
+| 0590 | Variables.tcl | sta_report_default_digits must be a positive integer. |
+| 0591 | Variables.tcl | sta_crpr_mode must be pin or transition. |
+| 0592 | Variables.tcl | $var_name value must be 0 or 1. |
+| 0593 | Variables.tcl | sta_pocv_mode must be scalar, normal, or skew_normal. |
+| 0594 | Variables.tcl | sta_pocv_quantile must be a positive floating point number. |
+| 0616 | Levelize.cc | maximum logic level exceeded |
+| 0617 | Levelize.cc | level check failed {} {} -> {} {} |
+| 0618 | Levelize.cc | maximum logic level exceeded |
+| 0620 | Sdf.tcl | -cond_use must be min, max or min_max. |
+| 0621 | Sdf.tcl | -cond_use min_max cannot be used with analysis type single. |
+| 0623 | Sdf.tcl | SDF -divider must be / or . |
+| 0624 | Sdf.tcl | -list_annotated is deprecated. Use -report_annotated. |
+| 0626 | Sdf.tcl | -list_annotated is deprecated. Use -report_annotated. |
+| 0627 | Sdf.tcl | -list_not_annotated is deprecated. Use -report_unannotated. |
+| 0800 | VcdParse.cc | unknown vcd command. |
+| 0801 | VcdParse.cc | timescale syntax error. |
+| 0802 | VcdParse.cc | Unknown timescale unit. |
+| 0804 | VcdParse.cc | Variable syntax error. |
+| 0805 | VcdParse.cc | invalid time {} |
+| 0806 | VcdParse.cc | time out of range {} |
+| 0807 | VcdParse.cc | unknown variable {} |
+| 0808 | VcdParse.cc | unknown variable {} |
+| 0809 | VcdParse.cc | Unknown variable type {}. |
+| 0820 | VcdReader.cc | No clocks have been defined. |
+| 1000 | ConcreteNetwork.cc | cell type {} can not be linked. |
+| 1010 | CycleAccting.cc | No common period was found between clocks {} and {}. |
+| 1040 | DmpCeff.cc | parasitic Pi model has NaNs. |
+| 1060 | Genclks.cc | no master clock found for generated clock {}. |
+| 1100 | GraphDelayCalc.cc | port not found in cell. |
+| 1101 | GraphDelayCalc.cc | mult_drvr missing load. |
+| 1110 | Liberty.cc | cell {}/{} port {} not found in cell {}/{}. |
+| 1111 | Liberty.cc | cell {}/{} {} -> {} timing group {} not found in cell {}/{}. |
+| 1112 | Liberty.cc | Liberty cell {}/{} for corner {}/{} not found. |
+| 1113 | Liberty.cc | cell {}/{} {} -> {} latch enable {}_edge is inconsistent with {} -> {} setup_{} check. |
+| 1114 | Liberty.cc | cell {}/{} {} -> {} latch enable {}_edge is inconsistent with latch group enable function positive sense. |
+| 1115 | Liberty.cc | cell {}/{} {} -> {} latch enable {}_edge is inconsistent with latch group enable function negative sense. |
+| 1116 | Liberty.cc | unsupported slew degradation table axes |
+| 1117 | Liberty.cc | unsupported slew degradation table axes |
+| 1118 | Liberty.cc | unsupported slew degradation table order |
+| 1119 | Liberty.cc | unsupported slew degradation table axes |
+| 1120 | Liberty.cc | library missing vdd |
+| 1121 | Liberty.cc | cell {}/{} no latch enable found for {} -> {}. |
+| 1128 | LibertyParser.cc | LibertyAttrValue::floatValue() called on string |
+| 1130 | LibExprReader.cc | {} references unknown port {}. |
+| 1131 | LibExprReader.cc | {} {}. |
+| 1140 | LibertyReader.cc | library {} already exists. |
+| 1141 | LibertyReader.cc | library missing name. |
+| 1142 | LibertyReader.cc | default_wire_load {} not found. |
+| 1143 | LibertyReader.cc | default_wire_selection {} not found. |
+| 1144 | LibertyReader.cc | default_operating_condition {} not found. |
+| 1145 | LibertyReader.cc | input_threshold_pct_{} not found. |
+| 1146 | LibertyReader.cc | output_threshold_pct_{} not found. |
+| 1147 | LibertyReader.cc | slew_lower_threshold_pct_{} not found. |
+| 1148 | LibertyReader.cc | slew_upper_threshold_pct_{} not found. |
+| 1150 | LibertyReader.cc | unknown unit multiplier {}. |
+| 1151 | LibertyReader.cc | unknown unit scale {}. |
+| 1152 | LibertyReader.cc | unknown unit suffix {}. |
+| 1153 | LibertyReader.cc | unknown unit suffix {}. |
+| 1154 | LibertyReader.cc | capacitive_load_units are not ff or pf. |
+| 1155 | LibertyReader.cc | capacitive_load_units are not a string. |
+| 1156 | LibertyReader.cc | capacitive_load_units missing suffix. |
+| 1157 | LibertyReader.cc | capacitive_load_units scale is not a float. |
+| 1158 | LibertyReader.cc | capacitive_load_units missing scale and suffix. |
+| 1160 | LibertyReader.cc | delay_model {} not supported. |
+| 1161 | LibertyReader.cc | delay_model {} not supported. |
+| 1162 | LibertyReader.cc | delay_model {} not supported. |
+| 1163 | LibertyReader.cc | delay_model {} not supported.. |
+| 1164 | LibertyReader.cc | unknown delay_model {}. |
+| 1165 | LibertyReader.cc | unknown bus_naming_style format. |
+| 1166 | LibertyReader.cc | voltage_map voltage is not a float. |
+| 1171 | LibertyReader.cc | {} is 0.0. |
+| 1172 | LibertyReader.cc | {} is 0.0. |
+| 1173 | LibertyReader.cc | non-increasing table index values. |
+| 1174 | LibertyReader.cc | default_wire_load_mode {} not found. |
+| 1175 | LibertyReader.cc | table template missing name. |
+| 1177 | LibertyReader.cc | missing table index values. |
+| 1178 | LibertyReader.cc | non-increasing table index values. |
+| 1179 | LibertyReader.cc | bus type missing bit_from. |
+| 1180 | LibertyReader.cc | bus type missing bit_to. |
+| 1183 | LibertyReader.cc | {} value {} is not a float. |
+| 1184 | LibertyReader.cc | wire_load missing name. |
+| 1185 | LibertyReader.cc | fanout_length is missing length and fanout. |
+| 1187 | LibertyReader.cc | wireload {} not found. |
+| 1189 | LibertyReader.cc | wire_load_from_area min not a float. |
+| 1190 | LibertyReader.cc | wire_load_from_area max not a float. |
+| 1191 | LibertyReader.cc | wire_load_from_area missing parameters. |
+| 1193 | LibertyReader.cc | cell missing name. |
+| 1196 | LibertyReader.cc | {} {} bus width mismatch. |
+| 1200 | LibertyReader.cc | latch enable function is non-unate for port {}. |
+| 1201 | LibertyReader.cc | latch enable function is unknown for port {}. |
+| 1202 | LibertyReader.cc | operating conditions {} not found. |
+| 1203 | LibertyReader.cc | scaled_cell missing operating condition. |
+| 1204 | LibertyReader.cc | scaled_cell cell {} has not been defined. |
+| 1205 | LibertyReader.cc | scaled_cell missing name. |
+| 1206 | LibertyReader.cc | scaled_cell {}, {} ports do not match cell ports |
+| 1207 | LibertyReader.cc | scaled_cell ports do not match cell ports. |
+| 1209 | LibertyReader.cc | combinational timing to an input port. |
+| 1210 | LibertyReader.cc | missing {}_transition. |
+| 1211 | LibertyReader.cc | missing cell_{}. |
+| 1212 | LibertyReader.cc | timing group from output port. |
+| 1213 | LibertyReader.cc | timing group from output port. |
+| 1214 | LibertyReader.cc | timing group from output port. |
+| 1215 | LibertyReader.cc | timing group from output port. |
+| 1219 | LibertyReader.cc | unsupported model axis. |
+| 1221 | LibertyReader.cc | output current waveform {:.2e} {:.2e} not found. |
+| 1224 | LibertyReader.cc | vector reference_time not found. |
+| 1227 | LibertyReader.cc | normalized_driver_waveform missing template. |
+| 1228 | LibertyReader.cc | level_shifter_type must be HL, LH, or HL_LH |
+| 1229 | LibertyReader.cc | switch_cell_type must be coarse_grain or fine_grain |
+| 1230 | LibertyReader.cc | scaling_factors {} not found. |
+| 1232 | LibertyReader.cc | pin {} not found. |
+| 1233 | LibertyReader.cc | pin name is not a string. |
+| 1234 | LibertyReader.cc | pin name is not a string. |
+| 1235 | LibertyReader.cc | bus_type {} not found. |
+| 1236 | LibertyReader.cc | bus_type not found. |
+| 1237 | LibertyReader.cc | OCV derate group named {} not found. |
+| 1238 | LibertyReader.cc | {} attribute is not boolean. |
+| 1239 | LibertyReader.cc | {} attribute is not boolean. |
+| 1240 | LibertyReader.cc | unknown port direction. |
+| 1241 | LibertyReader.cc | max_transition is 0.0. |
+| 1242 | LibertyReader.cc | pulse_latch unknown pulse type. |
+| 1243 | LibertyReader.cc | timing group missing related_pin/related_bus_pin. |
+| 1244 | LibertyReader.cc | unknown timing_type {}. |
+| 1245 | LibertyReader.cc | unknown timing_sense {}. |
+| 1246 | LibertyReader.cc | mode value is not a string. |
+| 1248 | LibertyReader.cc | mode name is not a string. |
+| 1249 | LibertyReader.cc | mode requirees 2 values. |
+| 1251 | LibertyReader.cc | unsupported model axis. |
+| 1253 | LibertyReader.cc | table template {} not found. |
+| 1254 | LibertyReader.cc | unsupported model axis. |
+| 1256 | LibertyReader.cc | table template {} not found. |
+| 1257 | LibertyReader.cc | {} is missing values. |
+| 1258 | LibertyReader.cc | {} is not a list of floats. |
+| 1259 | LibertyReader.cc | {} row has {} columns but axis has {}. |
+| 1260 | LibertyReader.cc | {} missing axis values. |
+| 1261 | LibertyReader.cc | {} has {} rows but axis has {}. |
+| 1262 | LibertyReader.cc | cell {} test_cell redefinition. |
+| 1263 | LibertyReader.cc | mode definition missing name. |
+| 1264 | LibertyReader.cc | mode value missing name. |
+| 1272 | LibertyReader.cc | {} is not a float. |
+| 1273 | LibertyReader.cc | {} is not a float. |
+| 1274 | LibertyReader.cc | {} requires 2 valules. |
+| 1277 | LibertyReader.cc | {} has no values. |
+| 1279 | LibertyReader.cc | {} attribute is not boolean. |
+| 1280 | LibertyReader.cc | {} attribute is not boolean. |
+| 1282 | LibertyReader.cc | attribute {} value {} not recognized. |
+| 1283 | LibertyReader.cc | unknown early/late value. |
+| 1284 | LibertyReader.cc | OCV derate group named {} not found. |
+| 1285 | LibertyReader.cc | ocv_derate missing name. |
+| 1286 | LibertyReader.cc | unknown rise/fall. |
+| 1287 | LibertyReader.cc | unknown derate type. |
+| 1288 | LibertyReader.cc | {} attribute is not boolean. |
+| 1289 | LibertyReader.cc | {} attribute is not boolean. |
+| 1290 | LibertyReader.cc | port {} not found. |
+| 1291 | LibertyReader.cc | unknown pg_type. |
+| 1292 | LibertyReader.cc | port {} subscript out of range. |
+| 1293 | LibertyReader.cc | port range {} of non-bus port {}. |
+| 1294 | LibertyReader.cc | port {} not found. |
+| 1295 | LibertyReader.cc | port {} not found. |
+| 1297 | LibertyReader.cc | axis type {} not supported. |
+| 1298 | LibertyReader.cc | statetable input port {} not found. |
+| 1299 | LibertyReader.cc | unknown signal_type {}. |
+| 1300 | LibertyReader.cc | table row must have 3 groups separated by ':'. |
+| 1301 | LibertyReader.cc | table row has {} input values but {} are required. |
+| 1303 | LibertyReader.cc | table row has {} next values but {} are required. |
+| 1304 | LibertyReader.cc | table input value '{}' not recognized. |
+| 1305 | LibertyReader.cc | table internal value '{}' not recognized. |
+| 1306 | LibertyReader.cc | port {} not found. |
+| 1307 | LibertyReader.cc | leakage_power missing value. |
+| 1308 | LibertyReader.cc | table template {} not found. |
+| 1309 | LibertyReader.cc | unknown early/late value. |
+| 1310 | LibertyReader.cc | {} is not a float. |
+| 1311 | LibertyReader.cc | no table models found in timing group. |
+| 1312 | LibertyReader.cc | ocv_derate_factors missing template. |
+| 1313 | LibertyReader.cc | bundle missing name. |
+| 1314 | LibertyReader.cc | pg_pin missing name. |
+| 1338 | Verilog.tcl | The -sort flag is ignored. |
+| 1340 | LibertyWriter.cc | {}/{} bundled ports not supported. |
+| 1341 | LibertyWriter.cc | {}/{}/{} timing model not supported. |
+| 1342 | LibertyWriter.cc | 3 axis table models not supported. |
+| 1343 | LibertyWriter.cc | {}/{}/{} timing arc type {} not supported. |
+| 1350 | LumpedCapDelayCalc.cc | gate delay load cap is NaN |
+| 1351 | LumpedCapDelayCalc.cc | gate delay input slew is NaN |
+| 1360 | TagGroup.cc | tag group missing tag |
+| 1370 | PathEnum.cc | path diversion missing edge. |
+| 1380 | MakeTimingModel.cc | clock {} pin {} is inside model block. |
+| 1390 | VerilogReader.cc | {} is not a verilog module. |
+| 1391 | VerilogReader.cc | {} is not a verilog module. |
+| 1440 | Bdd.cc | unknown function operator |
+| 1450 | VcdReader.cc | VCD max time is zero. |
+| 1451 | VcdReader.cc | problem parsing bus {}. |
+| 1453 | VcdReader.cc | clock {} pin {} has no vcd transitions. |
+| 1490 | Sdc.cc | group path name and is_default are mutually exclusive. |
+| 1510 | Search.cc | max tag group index exceeded |
+| 1511 | Search.cc | max tag index exceeded |
+| 1512 | Search.cc | unexpected filter path |
+| 1513 | Search.cc | tns incr existing vertex |
+| 1525 | SpefParse.yy | {} is not positive. |
+| 1526 | SpefParse.yy | {:.4f} is not positive. |
+| 1527 | SpefParse.yy | {:.4f} is not positive. |
+| 1550 | Sta.cc | '{}' is not a valid start point. |
+| 1551 | Sta.cc | '{}' is not a valid endpoint. |
+| 1552 | Sta.cc | '{}' is not a valid endpoint. |
+| 1553 | Sta.cc | maximum scene count exceeded |
+| 1554 | Sta.cc | '{}' is not a valid start point. |
+| 1555 | Sta.cc | liberty name/filename {} not found. |
+| 1556 | Sta.cc | multiple scenes reference mode {} |
+| 1557 | Sta.cc | net {} already exists. |
+| 1558 | Sta.cc | Spef file {} not found. |
+| 1559 | Sta.cc | Spef file {} not found. |
+| 1560 | Sta.cc | spef {} not found. |
+| 1561 | Sta.cc | mode {} not found. |
+| 1563 | Sta.cc | corresponding timing arc set not found in equiv cells |
+| 1570 | Sta.cc | No network has been linked. |
+| 1571 | Sta.cc | No network has been linked. |
+| 1572 | Sta.cc | mode {} not found. |
+| 1578 | Sta.cc | No liberty POCV/LVF models found. |
+| 1590 | Search.i | {} is not a known path group name. |
+| 1591 | Search.i | unknown report path field {} |
+| 1592 | Search.i | unknown common clk pessimism mode. |
+| 1601 | WriteSpice.cc | pg_pin {}/{} voltage {} not found, |
+| 1602 | WriteSpice.cc | Liberty pg_port {}/{} missing voltage_name attribute, |
+| 1603 | WriteSpice.cc | {} pg_port {} not found, |
+| 1604 | WriteSpice.cc | no register/latch found for path from {} to {}, |
+| 1605 | WriteSpice.cc | The subkct file {} is missing definitions for {} |
+| 1606 | WritePathSpice.cc | No instance with Liberty cell found in path. |
+| 1620 | WriteSdc.cc | unknown exception type |
+| 1621 | WriteSdc.cc | illegal set_logic value |
+| 1622 | WriteSdc.cc | invalid set_case_analysis value |
+| 1640 | SpefReader.cc | illegal bus delimiters. |
+| 1641 | SpefReader.cc | unknown units {}. |
+| 1642 | SpefReader.cc | unknown units {}. |
+| 1643 | SpefReader.cc | unknown units {}. |
+| 1644 | SpefReader.cc | unknown units {}. |
+| 1645 | SpefReader.cc | no name map entry for {}. |
+| 1646 | SpefReader.cc | unknown port direction {}. |
+| 1647 | SpefReader.cc | pin {}{}{} not found. |
+| 1648 | SpefReader.cc | instance {}{}{} not found. |
+| 1649 | SpefReader.cc | pin {} not found. |
+| 1650 | SpefReader.cc | net {} not found. |
+| 1651 | SpefReader.cc | {} not connected to net {}. |
+| 1652 | SpefReader.cc | pin {}{}{} not found. |
+| 1653 | SpefReader.cc | {}{}{} not connected to net {}. |
+| 1654 | SpefReader.cc | node {}{}{} not a pin or net:number |
+| 1655 | SpefReader.cc | {} not connected to net {}. |
+| 1656 | SpefReader.cc | pin {} not found. |
+| 1657 | SpefReader.cc | pin {} not found. |
+| 1658 | SpefReader.cc | {} |
+| 1670 | SpefParse.yy | {} |
+| 1700 | CcsCeffDelayCalc.cc | VDD not defined in library {} |
+| 1701 | CcsCeffDelayCalc.cc | unsupported ccs region count. |
+| 1751 | ArcDcalcWaveforms.cc | VDD not defined in library {} |
+| 1752 | PrimaDelayCalc.cc | G matrix is singular. |
+| 1754 | PrimaDelayCalc.cc | Port {}/{}/{} has no equivalent in scene {}. |
+| 1800 | Sdc.tcl | missing margin argument. |
+| 1801 | Sdc.tcl | '$args' ignored. |
+| 1802 | Sdc.tcl | -from, -through or -to required. |
+| 1860 | SaifReader.cc | {} |
+| 1861 | SaifReader.cc | SAIF TIMESCALE units not us, ns, or ps. |
+| 1862 | SaifReader.cc | SAIF TIMESCALE multiplier not 1, 10, or 100. |
+| 1866 | LibertyParser.cc | {} |
+| 1870 | VerilogReader.cc | {} |
+| 1903 | WriteSpice.tcl | Cannot write $spice_dir. |
+| 1904 | WriteSpice.tcl | No -spice_filename specified. |
+| 1905 | WriteSpice.tcl | -lib_subckt_file $lib_subckt_file is not readable. |
+| 1906 | WriteSpice.tcl | No -lib_subckt_file specified. |
+| 1907 | WriteSpice.tcl | -model_file $model_file is not readable. |
+| 1908 | WriteSpice.tcl | No -model_file specified. |
+| 1909 | WriteSpice.tcl | No -power specified. |
+| 1910 | WriteSpice.tcl | Unknown circuit simulator |
+| 1913 | WriteSpice.tcl | Cannot write $plot_dir. |
+| 1914 | WriteSpice.tcl | No -plot_basename specified. |
+| 1915 | WriteSpice.tcl | No -ground specified. |
+| 1920 | WriteSpice.tcl | Directory $spice_dir not found. |
+| 1921 | WriteSpice.tcl | $spice_dir is not a directory. |
+| 1922 | WriteSpice.tcl | Cannot write in $spice_dir. |
+| 1923 | WriteSpice.tcl | No -spice_file specified. |
+| 1924 | WriteSpice.tcl | -lib_subckt_file $lib_subckt_file is not readable. |
+| 1925 | WriteSpice.tcl | No -lib_subckt_file specified. |
+| 1926 | WriteSpice.tcl | -model_file $model_file is not readable. |
+| 1927 | WriteSpice.tcl | No -model_file specified. |
+| 1928 | WriteSpice.tcl | No -power specified. |
+| 1929 | WriteSpice.tcl | No -ground specified. |
+| 1930 | WriteSpice.tcl | No -path_args specified. |
+| 1931 | WriteSpice.tcl | No paths found for -path_args $path_args. |
+| 1932 | WriteSpice.tcl | Missing -gates argument. |
+| 1933 | WriteSpice.tcl | Missing -gates argument. |
+| 2100 | ArcDelayCalc.cc | no timing arc for {} input/driver pins. |
+| 2101 | ArcDelayCalc.cc | {} not a valid rise/fall. |
+| 2102 | ArcDelayCalc.cc | Pin {}/{} not found. |
+| 2103 | ArcDelayCalc.cc | {} not a valid rise/fall. |
+| 2104 | ArcDelayCalc.cc | Pin {}/{} not found. |
+| 2105 | ArcDelayCalc.cc | Instance {} not found. |
+| 2120 | Network.i | unknown namespace |
+| 2121 | Sdc.i | unknown analysis type |
+| 2122 | Sdc.i | unknown wire load mode |
+| 2123 | Sdc.i | unknown clock sense |
+| 2140 | TclTypeHelpers.cc | Delay calc arg requires 5 or 6 args. |
+| 2141 | Sta.cc | No liberty libraries found. |
+| 2150 | StaTclTypes.i | Unknown transition '{}'. |
+| 2151 | StaTclTypes.i | Unknown rise/fall edge '{}'. |
+| 2152 | StaTclTypes.i | Unknown transition name '{}'. |
+| 2153 | StaTclTypes.i | Unknown port direction '{}'. |
+| 2154 | StaTclTypes.i | Unknown timing role '{}'. |
+| 2155 | StaTclTypes.i | Unknown logic value '{}'. |
+| 2156 | StaTclTypes.i | Unknown analysis type '{}'. |
+| 2157 | StaTclTypes.i | {} is not a floating point number. |
+| 2158 | StaTclTypes.i | {} is not an integer. |
+| 2159 | StaTclTypes.i | {} not min or max. |
+| 2160 | StaTclTypes.i | {} not min, max or min_max. |
+| 2161 | StaTclTypes.i | {} not min, max or min_max. |
+| 2162 | StaTclTypes.i | {} not setup, hold, min or max. |
+| 2163 | StaTclTypes.i | {} not setup, hold, setup_hold, min, max or min_max. |
+| 2164 | StaTclTypes.i | {} not early/min, late/max or early_late/min_max. |
+| 2165 | StaTclTypes.i | {} not early/min, late/max or early_late/min_max. |
+| 2166 | StaTclTypes.i | {} not net_delay, cell_delay or cell_check. |
+| 2167 | StaTclTypes.i | {} not cell_delay or cell_check. |
+| 2168 | StaTclTypes.i | {} not clk or data. |
+| 2169 | StaTclTypes.i | {} not group or slack. |
+| 2170 | StaTclTypes.i | unknown path type {}. |
+| 2171 | StaTclTypes.i | unknown circuit simulator {}. |
+| 2173 | StaTclTypes.i | {} is not a scene object. |
+| 2174 | StaTclTypes.i | {} is not a mode object. |
+| 2175 | StaTclTypes.i | {} is not a floating point number. |
+| 2200 | Property.tcl | get_property object is null. |
+| 2201 | Property.tcl | get_property -object_type must be specified with object name argument. |
+| 2203 | Property.tcl | get_property unsupported object type $object_type. |
+| 2204 | Property.tcl | get_property $object is not an object. |
+| 2205 | Property.tcl | $object_type not supported. |
+| 2206 | Property.tcl | $object_type '$object_name' not found. |
+| 2207 | Property.tcl | define_property -object_type must be specified. |
+| 2208 | Property.tcl | define_property -type must be specified. |
+| 2209 | Property.i | define_property -object_type {} not supported. |
+| 2210 | Property.cc | unknown property type '{}' (use bool, float or string). |
+| 2211 | Property.cc | {} property '{}' is not defined. |
+| 2212 | Property.cc | '{}' is not a bool property value. |
+| 2213 | Property.tcl | set_property $object is not an object. |
+| 2214 | Property.i | set_property unsupported object type {}. |
+| 2215 | Property.cc | '{}' is not a float property value. |
+| 2300 | Bfs.cc | vertex {} level {} != bfs level {} |
+| 2400 | Power.cc | unknown cudd constant |
+| 2500 | DelayCalc.tcl | delay calculator $alg not found. |
+| 2501 | DelayCalc.tcl | set_assigned_delay missing -from argument. |
+| 2502 | DelayCalc.tcl | set_assigned_delay missing -to argument. |
+| 2503 | DelayCalc.tcl | set_assigned_delay delay is not a float. |
+| 2504 | DelayCalc.tcl | set_annotated_delay -cell and -net options are mutually excluive. |
+| 2505 | DelayCalc.tcl | set_assigned_delay pin [get_full_name $pin] is not attached to instance [get_full_name $inst]. |
+| 2506 | DelayCalc.tcl | set_assigned_delay pin [get_full_name $pin] is not attached to instance [get_full_name $inst] |
+| 2508 | DelayCalc.tcl | set_assigned_delay -cell or -net required. |
+| 2509 | DelayCalc.tcl | set_assigned_delay no timing arcs found between from/to pins. |
+| 2510 | DelayCalc.tcl | set_assigned_check missing -from argument. |
+| 2511 | DelayCalc.tcl | set_assigned_check -clock must be rise or fall. |
+| 2512 | DelayCalc.tcl | set_assigned_check missing -to argument. |
+| 2513 | DelayCalc.tcl | set_assigned_check missing -setup\|-hold\|-recovery\|-removal check type.. |
+| 2514 | DelayCalc.tcl | set_assigned_check check_value is not a float. |
+| 2516 | DelayCalc.tcl | set_assigned_check no check arcs found between from/to pins. |
+| 2518 | DelayCalc.tcl | set_assigned_transition transition is not a float. |
+| 2600 | FilterObjects.cc | -filter parsing failed at '{}'. |
+| 2601 | FilterObjects.cc | -filter extraneous ). |
+| 2602 | FilterObjects.cc | -filter extraneous ). |
+| 2603 | FilterObjects.cc | -filter unmatched (. |
+| 2604 | FilterObjects.cc | -filter logical OR requires at least two operands. |
+| 2605 | FilterObjects.cc | -filter logical AND requires two operands. |
+| 2606 | FilterObjects.cc | -filter NOT missing operand. |
+| 2607 | FilterObjects.cc | -filter expression is empty. |
+| 2608 | FilterObjects.cc | -filter expression evaluated to multiple sets. |
+| 2700 | ConcreteParasitics.cc | piModel called on non-PiElmore parasitic. |
+| 2701 | ConcreteParasitics.cc | setPiModel called on non-PiElmore parasitic. |
+| 2720 | ReportPath.cc | unknown path reporting field {}. |

--- a/etc/FindMessages.tcl
+++ b/etc/FindMessages.tcl
@@ -119,7 +119,7 @@ proc md_escape { text } {
   return [string map {| \\| ` \\`} $text]
 }
 
-proc report_msgs { {out_file ""} } {
+proc report_msgs { out_file include_lines } {
   global msgs
 
   if { $out_file != "" } {
@@ -136,7 +136,11 @@ proc report_msgs { {out_file ""} } {
   puts $out "| --- | --- | --- |"
   foreach msg_info $msgs {
     lassign $msg_info msg_id file line msg1
-    set loc "[file tail $file]"
+    if { $include_lines } {
+      set loc "[file tail $file]:$line"
+    } else {
+      set loc "[file tail $file]"
+    }
     puts $out "| [format %04d $msg_id] | $loc | [md_escape $msg1] |"
   }
   if { $out_file != "" } {
@@ -148,10 +152,22 @@ set msgs {}
 scan_files $files_c $warn_regexp_c
 scan_files $files_tcl $warn_regexp_tcl
 check_msgs
-if { $argc >= 1 } {
-  report_msgs [lindex $argv 0]
-} else {
-  report_msgs
+set out_file ""
+set lines_out_file ""
+
+for {set i 0} {$i < $argc} {incr i} {
+  set arg [lindex $argv $i]
+  if { $arg == "-lines_out" } {
+    incr i
+    set lines_out_file [lindex $argv $i]
+  } else {
+    set out_file $arg
+  }
+}
+
+report_msgs $out_file 0
+if { $lines_out_file != "" } {
+  report_msgs $lines_out_file 1
 }
 
 if {$has_error} {

--- a/etc/FindMessages.tcl
+++ b/etc/FindMessages.tcl
@@ -81,13 +81,37 @@ proc check_msgs { } {
 
   set msgs [lsort -index 0 -integer $msgs]
   set prev_id -1
+  set duplicates {}
+  set all_ids {}
+
   foreach msg $msgs {
     set msg_id [lindex $msg 0]
+    lappend all_ids $msg_id
     if { $msg_id == $prev_id } {
-      puts stderr "Warning: Message id $msg_id duplicated"
+      lappend duplicates $msg_id
       set has_error 1
     }
     set prev_id $msg_id
+  }
+
+  set duplicates [lsort -unique -integer $duplicates]
+
+  if { [llength $duplicates] > 0 } {
+    foreach dup_id $duplicates {
+      puts stderr "Error: Message id $dup_id duplicated in:"
+      foreach msg $msgs {
+        if { [lindex $msg 0] == $dup_id } {
+          puts stderr "  [lindex $msg 1]:[lindex $msg 2]"
+        }
+      }
+      
+      # Find the next free ID starting from dup_id
+      set next_free $dup_id
+      while { [lsearch -exact -integer $all_ids $next_free] >= 0 } {
+        incr next_free
+      }
+      puts stderr "  Suggested next available free ID: $next_free\n"
+    }
   }
 }
 
@@ -112,7 +136,7 @@ proc report_msgs { {out_file ""} } {
   puts $out "| --- | --- | --- |"
   foreach msg_info $msgs {
     lassign $msg_info msg_id file line msg1
-    set loc "[file tail $file]:$line"
+    set loc "[file tail $file]"
     puts $out "| [format %04d $msg_id] | $loc | [md_escape $msg1] |"
   }
   if { $out_file != "" } {


### PR DESCRIPTION
- Remove exact line numbers from generated Messages.md to prevent fragile CI failures when C++ files are modified.
- Enhance duplicate message ID detection to report the specific files and line numbers causing the collision.
- Enhance duplicate message ID detection to suggest the next available free ID for easy resolution.

I'm thinking the line numbers are not particularly valuable in the error messags as they could be different on origin/master and in a reported issue anyway: it can be trusted, but must be verified, so might as well leave out the line number from error messages.