### PR TITLE
Deploy MkDocs to the gh-pages branch instead of Actions Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,23 +1,21 @@
 name: GitHub Pages
 
-# Publishes MkDocs (mkdocs.yml) to GitHub Pages on every push to master.
-# Pages source: Settings → Pages → Build and deployment → GitHub Actions.
+# Publishes MkDocs (mkdocs.yml) to the gh-pages branch on every push to master.
+# Enable Pages: Settings → Pages → Deploy from a branch → gh-pages / (root).
 on:
   push:
     branches: [master]
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
-  group: pages
+  group: gh-pages
   cancel-in-progress: true
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -42,21 +40,8 @@ jobs:
       - name: Build docs
         run: mkdocs build --strict
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: site
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site


### PR DESCRIPTION
## Summary
- The GitHub Pages workflow fails at `actions/configure-pages` with `Get Pages site failed` / `Not Found` because Pages is not enabled on `parallaxsw/OpenSTA`.
- `GITHUB_TOKEN` cannot enable Pages (`enablement: true` requires a PAT or GitHub App token), so deploy the MkDocs site to the `gh-pages` branch with `peaceiris/actions-gh-pages` instead.
- After merge, enable Pages once: **Settings → Pages → Deploy from a branch → gh-pages / (root)**. Command docs at https://parallaxsw.github.io/OpenSTA/Commands/ can then load.

## Test plan
- [ ] GitHub Pages workflow on `master` (or workflow_dispatch) succeeds and pushes `site/` to `gh-pages`
- [ ] After enabling Pages from the `gh-pages` branch, https://parallaxsw.github.io/OpenSTA/ loads
- [ ] Generated command docs still run via `etc/build_sta.sh` before `mkdocs build --strict`


Made with [Cursor](https://cursor.com)