### PR TITLE
Fix zero wire delays with dmp_ceff_two_pole and read_spef -reduce

### DIFF
--- a/dcalc/DmpDelayCalc.cc
+++ b/dcalc/DmpDelayCalc.cc
@@ -148,6 +148,11 @@ public:
                            const RiseFall *rf,
                            const Scene *scene,
                            const MinMax *min_max) override;
+  Parasitic *reduceParasitic(const Parasitic *parasitic_network,
+                             const Pin *drvr_pin,
+                             const RiseFall *rf,
+                             const Scene *scene,
+                             const MinMax *min_max) override;
   ArcDcalcResult inputPortDelay(const Pin *port_pin,
                                 float in_slew,
                                 const RiseFall *rf,
@@ -173,6 +178,8 @@ protected:
                      // Return values.
                      double &wire_delay,
                      double &load_slew) override;
+
+  using ArcDelayCalc::reduceParasitic;
 
 private:
   void loadDelay(double drvr_slew,
@@ -239,8 +246,8 @@ DmpCeffTwoPoleDelayCalc::findParasitic(const Pin *drvr_pin,
   Parasitic *parasitic_network =
     parasitics->findParasiticNetwork(drvr_pin);
   if (parasitic_network) {
-    parasitic = parasitics->reduceToPiPoleResidue2(parasitic_network, drvr_pin, rf,
-                                                   scene, min_max);
+    parasitic = reduceParasitic(parasitic_network, drvr_pin, rf,
+                                scene, min_max);
     if (parasitic)
       return parasitic;
   }
@@ -255,6 +262,20 @@ DmpCeffTwoPoleDelayCalc::findParasitic(const Pin *drvr_pin,
                                              scene, min_max);
   }
   return parasitic;
+}
+
+// Reduce to PiPoleResidue, the format loadDelaySlew consumes; the
+// inherited PiElmore reduction yields zero wire delays.
+Parasitic *
+DmpCeffTwoPoleDelayCalc::reduceParasitic(const Parasitic *parasitic_network,
+                                         const Pin *drvr_pin,
+                                         const RiseFall *rf,
+                                         const Scene *scene,
+                                         const MinMax *min_max)
+{
+  Parasitics *parasitics = scene->parasitics(min_max);
+  return parasitics->reduceToPiPoleResidue2(parasitic_network, drvr_pin, rf,
+                                            scene, min_max);
 }
 
 ArcDcalcResult

--- a/test/dmp_two_pole_reduce.ok
+++ b/test/dmp_two_pole_reduce.ok
@@ -1,0 +1,31 @@
+Startpoint: r2 (rising edge-triggered flip-flop clocked by clk)
+Endpoint: r3 (rising edge-triggered flip-flop clocked by clk)
+Path Group: clk
+Path Type: max
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock clk (rise edge)
+   0.00    0.00   clock network delay (ideal)
+   0.00    0.00 ^ r2/CLK (DFFHQx4_ASAP7_75t_R)
+  76.55   76.55 ^ r2/Q (DFFHQx4_ASAP7_75t_R)
+  17.51   94.05 ^ u1/A (BUFx2_ASAP7_75t_R)
+  47.34  141.39 ^ u1/Y (BUFx2_ASAP7_75t_R)
+  17.49  158.88 ^ u2/B (AND2x2_ASAP7_75t_R)
+  55.96  214.84 ^ u2/Y (AND2x2_ASAP7_75t_R)
+  17.57  232.41 ^ r3/D (DFFHQx4_ASAP7_75t_R)
+         232.41   data arrival time
+
+ 500.00  500.00   clock clk (rise edge)
+   0.00  500.00   clock network delay (ideal)
+   0.00  500.00   clock reconvergence pessimism
+         500.00 ^ r3/CLK (DFFHQx4_ASAP7_75t_R)
+ -22.94  477.06   library setup time
+         477.06   data required time
+---------------------------------------------------------
+         477.06   data required time
+        -232.41   data arrival time
+---------------------------------------------------------
+         244.65   slack (MET)
+
+

--- a/test/dmp_two_pole_reduce.tcl
+++ b/test/dmp_two_pole_reduce.tcl
@@ -1,0 +1,11 @@
+# dmp_ceff_two_pole with read_spef -reduce
+# The reduce hook must produce PiPoleResidue parasitics for the two pole
+# delay calculator. If it produces PiElmore instead, loadDelaySlew ignores
+# the parasitic and wire delays are zero.
+read_liberty asap7_small.lib.gz
+read_verilog reg1_asap7.v
+link_design top
+create_clock -name clk -period 500 {clk1 clk2 clk3}
+set_delay_calculator dmp_ceff_two_pole
+read_spef -reduce reg1_asap7.spef
+report_checks -fields {input_pins}

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -142,6 +142,7 @@ record_example_tests {
 
 record_public_tests {
   disconnect_mcp_pin
+  dmp_two_pole_reduce
   get_filter
   get_is_buffer
   get_is_memory


### PR DESCRIPTION
DmpCeffTwoPoleDelayCalc inherited LumpedCapDelayCalc::reduceParasitic, which reduces to PiElmore. Its loadDelaySlew only reads pole/residue data, so reduced parasitics gave zero wire delay and load slew equal to driver slew.

Override reduceParasitic to reduce to PiPoleResidue, and route findParasitic through the virtual so the reduction is chosen in one place.

Adds regression test dmp_two_pole_reduce.