### PR TITLE
Fix use-after-free deleting a pin that has an input/output delay

### DIFF
--- a/include/sta/Sdc.hh
+++ b/include/sta/Sdc.hh
@@ -1052,7 +1052,9 @@ public:
   void unrecordException(ExceptionPath *exception);
 
   // Network edit before/after methods.
-  void deletePinBefore(const Pin *pin);
+  // Returns true if an input/output delay was deleted, which strands the
+  // search tags that reference it.
+  bool deletePinBefore(const Pin *pin);
   void connectPinAfter(const Pin *pin);
   void clkHpinDisablesChanged(const Pin *pin);
   void makeClkHpinDisable(const Clock *clk,
@@ -1228,6 +1230,7 @@ protected:
                          InputDelay *except);
   void deleteInputDelaysReferencing(const Clock *clk);
   void deleteInputDelay(InputDelay *input_delay);
+  bool deletePortDelaysReferencing(const Pin *pin);
 
   OutputDelay *findOutputDelay(const Pin *pin,
                                const ClockEdge *clk_edge);

--- a/sdc/Sdc.cc
+++ b/sdc/Sdc.cc
@@ -5722,7 +5722,7 @@ Sdc::connectPinAfter(const Pin *pin)
   }
 }
 
-void
+bool
 Sdc::deletePinBefore(const Pin *pin)
 {
   auto itr = pin_exceptions_.find(pin);
@@ -5750,7 +5750,90 @@ Sdc::deletePinBefore(const Pin *pin)
     first_to_pin_exceptions_.erase(pin);
     pin_exceptions_.erase(pin);
   }
+  bool port_delay_deleted = deletePortDelaysReferencing(pin);
   drvr_pin_wire_cap_map_.erase(pin);
+  return port_delay_deleted;
+}
+
+// Erase pin's entry from a pin map, deleting the set the map owns.
+template <class PinMap>
+static void
+deletePinMapKey(PinMap &pin_map,
+                const Pin *pin)
+{
+  auto itr = pin_map.find(pin);
+  if (itr != pin_map.end()) {
+    delete itr->second;
+    pin_map.erase(itr);
+  }
+}
+
+// Input/output delays reference pins in the delay objects and as keys in
+// the pin maps.  The maps are ordered by PinIdLess, which dereferences the
+// pin, so a key left behind for a deleted pin corrupts every subsequent
+// lookup.  Remove all references while the pin is still valid.
+// Returns true if a delay was deleted.
+bool
+Sdc::deletePortDelaysReferencing(const Pin *pin)
+{
+  bool port_delay_deleted = false;
+
+  // Delays on a hierarchical pin that expands to this leaf pin survive
+  // without it.
+  InputDelaySet *leaf_input_delays = inputDelaysLeafPin(pin);
+  if (leaf_input_delays) {
+    for (InputDelay *input_delay : *leaf_input_delays) {
+      if (input_delay->pin() != pin)
+        input_delay->leafPins().erase(pin);
+    }
+  }
+  // Ref pins are not indexed by pin.
+  if (have_input_delay_ref_pins_) {
+    for (InputDelay *input_delay : input_delays_) {
+      if (input_delay->refPin() == pin)
+        input_delay->setRefPin(nullptr);
+    }
+  }
+  InputDelaySet *pin_input_delays = findKey(input_delay_pin_map_, pin);
+  if (pin_input_delays) {
+    for (auto itr = pin_input_delays->begin();
+         itr != pin_input_delays->end(); /* no incr */) {
+      InputDelay *input_delay = *itr;
+      itr = pin_input_delays->erase(itr);
+      deleteInputDelay(input_delay);
+      port_delay_deleted = true;
+    }
+  }
+  deletePinMapKey(input_delay_pin_map_, pin);
+  deletePinMapKey(input_delay_leaf_pin_map_, pin);
+  deletePinMapKey(input_delay_internal_pin_map_, pin);
+
+  OutputDelaySet *leaf_output_delays = outputDelaysLeafPin(pin);
+  if (leaf_output_delays) {
+    for (OutputDelay *output_delay : *leaf_output_delays) {
+      if (output_delay->pin() != pin)
+        output_delay->leafPins().erase(pin);
+    }
+  }
+  // There is no have_output_delay_ref_pins_ flag to skip this scan.
+  for (OutputDelay *output_delay : output_delays_) {
+    if (output_delay->refPin() == pin)
+      output_delay->setRefPin(nullptr);
+  }
+  OutputDelaySet *pin_output_delays = findKey(output_delay_pin_map_, pin);
+  if (pin_output_delays) {
+    for (auto itr = pin_output_delays->begin();
+         itr != pin_output_delays->end(); /* no incr */) {
+      OutputDelay *output_delay = *itr;
+      itr = pin_output_delays->erase(itr);
+      deleteOutputDelay(output_delay);
+      port_delay_deleted = true;
+    }
+  }
+  deletePinMapKey(output_delay_pin_map_, pin);
+  deletePinMapKey(output_delay_leaf_pin_map_, pin);
+
+  return port_delay_deleted;
 }
 
 void

--- a/search/Sta.cc
+++ b/search/Sta.cc
@@ -5038,11 +5038,17 @@ Sta::deletePinBefore(const Pin *pin)
     }
   }
 
+  bool port_delay_deleted = false;
   for (const Mode *mode : modes_) {
-    mode->sdc()->deletePinBefore(pin);
+    port_delay_deleted |= mode->sdc()->deletePinBefore(pin);
     mode->sim()->deletePinBefore(pin);
     mode->clkNetwork()->deletePinBefore(pin);
   }
+  // Tags reference the input delay they were seeded from, so deleting one
+  // strands them (Sta::removeClock invalidates for the same reason).
+  // Rare enough not to defeat the incremental updates above.
+  if (port_delay_deleted)
+    search_->arrivalsInvalid();
 }
 
 void

--- a/test/delete_instance_port_delay.ok
+++ b/test/delete_instance_port_delay.ok
@@ -1,0 +1,28 @@
+Startpoint: r1 (rising edge-triggered flip-flop clocked by clk)
+Endpoint: r3 (rising edge-triggered flip-flop clocked by clk)
+Path Group: clk
+Path Type: max
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock clk (rise edge)
+   0.00    0.00   clock network delay (ideal)
+   0.00    0.00 ^ r1/CLK (DFFHQx4_ASAP7_75t_R)
+  64.69   64.69 ^ r1/Q (DFFHQx4_ASAP7_75t_R)
+  18.36   83.04 ^ u2/Y (AND2x2_ASAP7_75t_R)
+   0.00   83.04 ^ r3/D (DFFHQx4_ASAP7_75t_R)
+          83.04   data arrival time
+
+1000.00 1000.00   clock clk (rise edge)
+   0.00 1000.00   clock network delay (ideal)
+   0.00 1000.00   clock reconvergence pessimism
+        1000.00 ^ r3/CLK (DFFHQx4_ASAP7_75t_R)
+ -12.79  987.21   library setup time
+         987.21   data required time
+---------------------------------------------------------
+         987.21   data required time
+         -83.04   data arrival time
+---------------------------------------------------------
+         904.17   slack (MET)
+
+

--- a/test/delete_instance_port_delay.tcl
+++ b/test/delete_instance_port_delay.tcl
@@ -1,0 +1,9 @@
+read_liberty asap7_small.lib.gz
+read_verilog reg1_asap7.v
+link_design top
+create_clock -name clk -period 1000 {clk1 clk2 clk3}
+# Port delays on the pins of an instance that is deleted below.
+set_output_delay -clock clk 130 [get_pins u1/Y]
+set_input_delay -clock clk 120 [get_pins u1/A]
+delete_instance u1
+report_checks

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -141,6 +141,7 @@ record_example_tests {
 }
 
 record_public_tests {
+  delete_instance_port_delay
   disconnect_mcp_pin
   dmp_two_pole_reduce
   get_filter


### PR DESCRIPTION
Fix for https://github.com/parallaxsw/OpenSTA/issues/511
set_input_delay or set_output_delay on an instance pin, then
delete_instance on that instance, left the freed Pin * as a key in the
five port delay maps in Sdc. Those maps are ordered by PinIdLess, which
reads the pin's network id, so the stale key broke every later lookup in the
map, not just a lookup of the deleted pin. The first bad read is
Sdc::hasInputDelay() from Search::seedInputArrival(). A normal build
prints plausible numbers; ASAN aborts with a heap-use-after-free.

Sdc::deletePinBefore() now drops every reference to the pin while it is
still valid: deletes the delays set on it, removes it from leafPins() of
delays on hierarchical pins that expand to it, clears refPin(), and erases
the key from all five maps. Sta::deletePinBefore() calls
search_->arrivalsInvalid() when a delay was deleted, since Tag holds the
InputDelay * it was seeded from, the same reason Sta::removeClock does it.

Test added as test/delete_instance_port_delay.tcl/ok. It passes in a normal build
with or without the fix, since the corrupted reads happen to return usable
values; can be run under ASAN to see the failure.