### PR TITLE
fix latch & ff equivalent cell issue

### DIFF
--- a/liberty/EquivCells.cc
+++ b/liberty/EquivCells.cc
@@ -377,12 +377,19 @@ equivCellSequentials(const LibertyCell *cell1,
        seq_itr1++, seq_itr2++) {
     const Sequential &seq1 = *seq_itr1;
     const Sequential &seq2 = *seq_itr2;
-    if (!(FuncExpr::equiv(seq1.clock(), seq2.clock())
+    // isRegister distinguishes an edge triggered ff group from a level
+    // sensitive latch group.  Without it a ff and a latch that happen to
+    // share port names and output functions compare equivalent, and
+    // cell sizing can swap one for the other.
+    if (!(seq1.isRegister() == seq2.isRegister()
+          && FuncExpr::equiv(seq1.clock(), seq2.clock())
           && FuncExpr::equiv(seq1.data(), seq2.data())
           && LibertyPort::equiv(seq1.output(), seq2.output())
           && LibertyPort::equiv(seq1.outputInv(), seq2.outputInv())
           && FuncExpr::equiv(seq1.clear(), seq2.clear())
-          && FuncExpr::equiv(seq1.preset(), seq2.preset())))
+          && FuncExpr::equiv(seq1.preset(), seq2.preset())
+          && seq1.clearPresetOutput() == seq2.clearPresetOutput()
+          && seq1.clearPresetOutputInv() == seq2.clearPresetOutputInv()))
       return false;
   }
   return seq_itr1 == seqs1.end() && seq_itr2 == seqs2.end();

--- a/liberty/EquivCells.cc
+++ b/liberty/EquivCells.cc
@@ -377,10 +377,8 @@ equivCellSequentials(const LibertyCell *cell1,
        seq_itr1++, seq_itr2++) {
     const Sequential &seq1 = *seq_itr1;
     const Sequential &seq2 = *seq_itr2;
-    // isRegister distinguishes an edge triggered ff group from a level
-    // sensitive latch group.  Without it a ff and a latch that happen to
-    // share port names and output functions compare equivalent, and
-    // cell sizing can swap one for the other.
+    // isRegister separates ff groups from latch groups; without it, ff and
+    // latch cells with matching ports and functions compare equivalent.
     if (!(seq1.isRegister() == seq2.isRegister()
           && FuncExpr::equiv(seq1.clock(), seq2.clock())
           && FuncExpr::equiv(seq1.data(), seq2.data())

--- a/tcl/StaTclTypes.i
+++ b/tcl/StaTclTypes.i
@@ -206,10 +206,14 @@ seqPtrTclList(SEQ_TYPE *seq,
               Tcl_Interp *interp)
 {
   Tcl_Obj *list = Tcl_NewListObj(0, nullptr);
-  for (const OBJECT_TYPE *obj : *seq) {
-    Tcl_Obj *tcl_obj = SWIG_NewInstanceObj(const_cast<OBJECT_TYPE*>(obj),
-                                           swig_type, false);
-    Tcl_ListObjAppendElement(interp, list, tcl_obj);
+  // A null sequence is an empty result, not a crash.  Functions like
+  // find_equiv_cells return null when there is nothing to report.
+  if (seq) {
+    for (const OBJECT_TYPE *obj : *seq) {
+      Tcl_Obj *tcl_obj = SWIG_NewInstanceObj(const_cast<OBJECT_TYPE*>(obj),
+                                             swig_type, false);
+      Tcl_ListObjAppendElement(interp, list, tcl_obj);
+    }
   }
   Tcl_SetObjResult(interp, list);
 }

--- a/test/equiv_cells_ff_latch.ok
+++ b/test/equiv_cells_ff_latch.ok
@@ -1,0 +1,4 @@
+equiv_cell_ports ff latch: 1
+equiv_cells ff latch: 0
+find_equiv_cells ff: 0
+find_equiv_cells DFFHQNx1: 3

--- a/test/equiv_cells_ff_latch.tcl
+++ b/test/equiv_cells_ff_latch.tcl
@@ -1,0 +1,25 @@
+# DFFHQx4 and DHLx1 have the same ports, the same Q function and the same
+# clock/data expressions.  Only the ff/latch group differs, so they must not
+# compare equivalent.
+#
+# find_equiv_cells on a cell with no equivalents returns an empty list rather
+# than crashing.
+
+read_liberty asap7_seq.lib.gz
+
+set lib asap7sc7p5t_SEQ_RVT_TT_ccs_220123
+set ff [get_lib_cell $lib/DFFHQx4_ASAP7_75t_R]
+set latch [get_lib_cell $lib/DHLx1_ASAP7_75t_R]
+
+# The ports match, which is what puts the two cells in the same hash bucket.
+puts "equiv_cell_ports ff latch: [sta::equiv_cell_ports $ff $latch]"
+puts "equiv_cells ff latch: [sta::equiv_cells $ff $latch]"
+
+sta::make_equiv_cells [lindex [get_libs $lib] 0]
+
+# DFFHQx4 is the only x4 drive ff, so it has no equivalents.
+puts "find_equiv_cells ff: [llength [sta::find_equiv_cells $ff]]"
+
+# DFFHQNx1/x2/x3 are equivalent to each other, so the ff group must survive.
+set ffn [get_lib_cell $lib/DFFHQNx1_ASAP7_75t_R]
+puts "find_equiv_cells DFFHQNx1: [llength [sta::find_equiv_cells $ffn]]"

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -143,6 +143,7 @@ record_example_tests {
 record_public_tests {
   disconnect_mcp_pin
   dmp_two_pole_reduce
+  equiv_cells_ff_latch
   get_filter
   get_is_buffer
   get_is_memory


### PR DESCRIPTION
Fix for two independent issues, can split if you prefer.

### Issue 1
equivCellSequentials() never compared isRegister(), so a ff and a latch with
matching ports and output functions compared equivalent. ASAP7 has such a pair
(DFFHQx4/DHLx1). Arcs don't catch it: equivCells() only falls back to
equivCellTimingArcSets() when cellHasFuncs() is false, and a sequential cell has
function : "IQ". hashSequential() already includes isRegister(), so
make_equiv_cells mostly hides it, but sta::equivCells() is public.

Also added clearPresetOutput()/clearPresetOutputInv(), which hashSequential()
covers and this did not. Compared with == rather than the FuncExpr::equiv /
LibertyPort::equiv used by the surrounding terms, since these are values (bool,
LogicValue) rather than pointers that can be null.

### Issue 2
seqPtrTclList() dereferenced *seq unconditionally. EquivCells::equivs() returns
findKey() directly, so find_equiv_cells segfaulted on a cell with no
equivalents. Guarded at the template, covering all six instantiations; null now
gives an empty list.

test/equiv_cells_ff_latch covers both, reusing test/asap7_seq.lib.gz. 
Without this fix, it prints "equiv_cells ff latch: 1" and then segfaults. 